### PR TITLE
docs: add OpenAPI, error handling and ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ A API estará disponível em: **http://localhost:3000**
 | [📁 Estrutura do Projeto](docs/project-structure.md) | Organização detalhada do monorepo |
 | [🔄 Exemplos](docs/examples.md) | Fluxos completos com código e diagramas |
 | [🧪 Testes](docs/testing.md) | Jest, testes unitários, integração e E2E |
+| [📐 OpenAPI / Swagger](docs/openapi.md) | Configuração do Swagger, integração com Zod, boas práticas |
+| [⚠️ Error Handling](docs/error-handling.md) | Contrato de erros, envelope, mapeamento de exceções |
 
 ### 🔗 Links Rápidos
 
@@ -288,7 +290,8 @@ yarn test:e2e
 - [ ] **Alertas de Estoque** - Notificação quando estoque < mínimo
 - [ ] **Gestão de Clientes** - CRUD de clientes
 - [ ] **Pagamentos** - Integração com gateways
-- [ ] **API Documentation** - Swagger/OpenAPI
+ - [x] **API Documentation** - Swagger/OpenAPI ([📐 OpenAPI / Swagger](docs/openapi.md))
+
 - [ ] **Rate Limiting** - Proteção contra abuso
 - [ ] **Caching** - Redis para listagens
 - [ ] **CI/CD** - GitHub Actions

--- a/docs/adr/0001-idioma-mensagens-de-erro.md
+++ b/docs/adr/0001-idioma-mensagens-de-erro.md
@@ -1,0 +1,129 @@
+# ADR-0001: 🌐 Idioma das mensagens de erro
+
+## Status
+Aceito
+
+## Contexto
+A API precisa retornar mensagens de erro legíveis por humanos para consumidores (clientes internos, integrações e times de produto). Durante discussões do time surgiram dúvidas sobre qual idioma adotar para os campos que expõem texto destinado a humanos (por exemplo: message, details) e também sobre o formato/estrutura desses erros. É necessário documentar uma decisão clara e rastreável para evitar inconsistências na experiência do consumidor e dívida técnica avoidable.
+
+Requisitos/contexto adicional considerado:
+- Consumidores iniciais são majoritariamente internos e no Brasil.
+- Convenção de código do repositório: todo código em inglês; documentação em pt-BR (ver [convenções do projeto](../conventions.md)).
+
+## Decisão
+As mensagens de erro direcionadas a humanos (campos como message e details em respostas HTTP e payloads de eventos de erro) serão escritas em português do Brasil (pt-BR) na primeira etapa do produto.
+
+Regras explícitas desta decisão:
+- O campo identificador do erro (campo error / code / nome do tipo/exceção) permanecerá em inglês, pois é um identificador técnico (ex.: "ProductNotFoundException", "InvalidRequestError").
+- Mensagens legíveis por humanos (ex.: message, details[].message) serão em pt-BR.
+- Mensagens centralizadas devem ser colocadas em: libs/shared/src/errors/messages/ (mensagens atuais podem começar como arquivos .ts/.json contendo chaves e textos pt-BR).
+- Internacionalização (i18n) é reconhecida como necessidade futura, mas está fora do escopo imediato. Este ADR documenta a decisão temporária e o caminho de migração.
+
+Exemplo de payload de erro (padrão recomendado):
+
+```json
+{
+  "error": "ProductNotFoundException",
+  "message": "Produto não encontrado para o id informado",
+  "details": [
+    { "field": "productId", "message": "Nenhum produto com este id foi localizado" }
+  ]
+}
+```
+
+## Consequências
+### Positivas
+- Melhor experiência imediata para consumidores internos brasileiros — mensagens claras no idioma de negócio.
+- Menor overhead de implementação e complexidade operacional no curto prazo (sem necessidade de infra/arquivos de tradução, lógica de fallback, testes de compatibilidade).
+
+### Negativas / Trade-offs
+- Mensagens em pt-BR tornam a futura internacionalização mais trabalhosa: texto pode estar espalhado ou hardcoded em lugares não centralizados.
+- Integrações internacionais (se aparecerem) terão experiência degradada até que i18n seja adotado.
+
+### Riscos e Dívida Técnica
+- Risco de mensagens espalhadas: se as mensagens não forem centralizadas desde o começo, será necessário esforço de refactor maior.
+- Dívida técnica: strings do usuário em pt-BR são uma camada de dívida que exigirá mapeamento para chaves de tradução e possíveis mudanças em payloads de erro.
+- Mitigação: centralizar mensagens desde já em libs/shared/src/errors/messages/ e usar constantes/keys mesmo que o valor final seja pt-BR.
+
+## Alternativas Consideradas
+
+| Alternativa | Descrição | Por que foi descartada/observações |
+|---|---:|---|
+| Inglês desde o início | Usar inglês para todas as mensagens legíveis por humanos | Pro: prepara internacionalização; Con: pior experiência para time/consumidores internos que esperam pt-BR; aumento de atrito para suporte/POs. Considerada, mas não alinhada ao público atual.
+| i18n desde o início (ex: i18next) | Implementar suporte a múltiplos idiomas já na primeira entrega | Pro: evita dívida; Con: aumento de complexidade e tempo de entrega (infra, arquivos de tradução, testes, processo de atualização de traduções). Descartada por custo/overhead inicial.
+| pt-BR agora, i18n depois (decisão tomada) | Mensagens em pt-BR, centralizadas; planejar migração para i18n | Pro: entrega rápida e boa UX para público atual; Con: dívida técnica que precisa ser gerenciada. Escolhida por equilíbrio entre valor e custo.
+
+## Plano de Migração Futuro (i18n)
+Quando for necessário suportar múltiplos idiomas, seguir o plano abaixo.
+
+Passos concretos:
+1. Marcar este ADR como "Substituído por ADR-XXXX" (criar novo ADR para i18n) e manter histórico.
+2. Adotar uma biblioteca de i18n: sugerimos i18next (por maturidade, eco-sistema Node/TS e suporte a namespaces e pluralização).
+3. Estrutura de arquivos de tradução:
+   - libs/shared/i18n/locales/pt-BR.json
+   - libs/shared/i18n/locales/en-US.json
+   - etc.
+4. Refatoração incremental:
+   - Passo 0 (pré-condição): garantir que todas as mensagens estejam centralizadas em libs/shared/src/errors/messages/ como chaves/constantes. Exemplo:
+
+```ts
+// libs/shared/src/errors/messages/product.ts
+export const ProductMessages = {
+  ProductNotFound: 'Produto não encontrado para o id informado',
+}
+```
+
+   - Passo 1: adicionar um adaptador mínimo que resolve chaves para textos usando i18next, mantendo fallback para as strings existentes (dual-read): quando uma chave existe no i18next usa-se ela, senão usa-se o texto pt-BR atual.
+   - Passo 2: substituir chamadas diretas a textos por lookup por chave (ex: t('errors.product.not_found')). Isso pode ser feito por refactors em módulos individuais com cobertura de testes.
+   - Passo 3: publicar traduções em en-US (ou outro idioma alvo) e validar com testes de contrato e e2e com header Accept-Language.
+5. API backward-compatibility:
+   - A estrutura do JSON (campos error, message, details) não deve mudar. Inicialmente, incluir um novo campo opcional metadata.locale quando aplicável. Exemplo:
+
+```json
+{
+  "error": "ProductNotFoundException",
+  "message": "Produto não encontrado para o id informado",
+  "metadata": { "locale": "pt-BR" }
+}
+```
+
+   - Alternativa mais suave: aceitar header Accept-Language e retornar message no idioma solicitado sem alterar shape.
+6. Estratégia de rollout:
+   - Migrar serviço por serviço (strangler pattern). Em cada serviço, trocar uso direto de strings por chaves, habilitar i18n por feature flag e monitorar erros/regressões.
+   - Para consumidores externos, documentar o novo comportamento e oferecer período de coexistência.
+7. Testes e validação:
+   - Contract tests que validam shape dos erros (independente do idioma).
+   - Testes de integração que validam header Accept-Language/locale behaviour.
+8. Substituição do ADR:
+   - Ao completar migração, criar ADR-XXXX que documenta suporte a i18n e marcar este ADR como "Substituído por ADR-XXXX".
+
+Observações práticas sobre ferramentas e localização de código:
+- Biblioteca sugerida: i18next (node + typescript). Alternativas: FormatJS, lingui. i18next tem suporte a namespaces e carregamento assíncrono de recursos.
+- Local sugerida para centralizar mensagens desde já: libs/shared/src/errors/messages/ (trocar para chaves/constantes para facilitar mapeamento futuro).
+- Quando migrar, preferir abordagem de mapeamento por chave (key -> localized string) em vez de regex/patching de strings.
+
+Mermaid — visão de alto nível do fluxo de erro e migração
+
+```mermaid
+flowchart LR
+  Client[Cliente -> API]
+  API[API Service]
+  Messages[libs/shared/src/errors/messages]
+  i18n[i18n adapter (i18next)]
+
+  Client -->|request| API
+  API -->|throws| Messages
+  Messages -->|pt-BR text| API
+  API -->|response (message: pt-BR)| Client
+
+  subgraph Future migration
+    Messages -->|refactor to keys| i18n
+    i18n -->|localized text| API
+  end
+```
+
+## Referências
+- [Conventions do projeto](../conventions.md)
+- i18next: https://www.i18next.com/
+
+[⬆ Voltar para README](../../README.md)

--- a/docs/adr/0002-error-handler-centralizado.md
+++ b/docs/adr/0002-error-handler-centralizado.md
@@ -1,0 +1,167 @@
+# ADR-0002: 🛑 Handler de Erros Centralizado
+
+## Escopo
+Documenta a decisão de usar um único handler de erros global e centralizado na API construída com Fastify (NX monorepo, TypeScript, DDD + Clean Architecture).
+
+## Resumo Executivo
+Aceitamos um ponto único de tratamento de exceções registrado com fastify.setErrorHandler(handler) durante a bootstrap da aplicação. O handler classifica erros em três categorias (erros de domínio, erros de validação Zod e erros não mapeados), aplica mapeamentos HTTP consistentes e expõe respostas previsíveis ao cliente, preservando logs ricos para diagnóstico.
+
+# ADR-0002: Handler de Erros Centralizado
+
+## Status
+Aceito
+
+## Contexto
+A API precisa de uma estratégia consistente para capturar, normalizar e formatar exceções antes de enviá-las ao cliente. O Fastify fornece um ponto de extensão global via fastify.setErrorHandler(handler) e também permite handlers por escopo/plugin. Sem convenção clara, mensagens e status retornados podem variar entre endpoints, prejudicando consumidores e a observabilidade.
+
+Assumptions (pressupostos):
+- Projeto: apps/api usando Fastify.
+- ADR-0001 já trata i18n/idioma das mensagens (ver Referências).
+- Código da API está em inglês, documentação em pt-BR.
+
+## Decisão
+Registrar um único handler global e centralizado via fastify.setErrorHandler(handler) durante a bootstrap da aplicação. Arquivo sugerido para implementação: `apps/api/src/plugins/error-handler.plugin.ts`.
+
+O handler recebe qualquer erro lançado em qualquer rota e o classifica em 3 categorias:
+
+1. Erros de Domínio (DomainError — classe base): erros do domínio são subclasses de DomainError e mapeados para HTTP por um mapa explícito (`errorMap`). O DomainError deve carregar informações mínimas: código interno (nome da classe), mensagem legível (padrão em pt-BR, sujeito a ADR-0001) e dados opcionais para contexto.
+2. Erros de Validação Zod (ZodError): mapeados para 400 com um payload que inclui `details[]` com informações de cada campo inválido.
+3. Erros não mapeados: qualquer outro erro. O handler registra a mensagem/stack completa usando o logger do Fastify e expõe ao cliente uma mensagem genérica e não sensível.
+
+Implementação técnica (pontos-chave):
+- O handler é registrado com fastify.setErrorHandler(...) na bootstrap (ex.: apps/api/src/main.ts ou plugin de bootstrap).
+- Arquivo sugerido: `apps/api/src/plugins/error-handler.plugin.ts`.
+- Mantemos um `errorMap` no plugin que traduz classes de erro de domínio para status HTTP e campos `error`/`message` públicos.
+- O handler deve ser resiliente a formatos inesperados (ex.: erros de bibliotecas externas) e sempre ter um fallback para 500.
+
+Mermaid - fluxo simplificado
+
+```mermaid
+flowchart LR
+  Client[Cliente] -->|HTTP| Route[Route/Controller]
+  Route -->|throw / reject| FastifyErrorHandler[fastify.setErrorHandler]
+  FastifyErrorHandler -->|DomainError mapeado| DomainMap[Map → HTTP (4xx/409/...)]
+  FastifyErrorHandler -->|ZodError| ZodResp[400 + details[]]
+  FastifyErrorHandler -->|Não mapeado| GenericResp[500 + mensagem genérica]
+  DomainMap --> Reply[Reply enviada]
+  ZodResp --> Reply
+  GenericResp --> Log[Logger (stack)] --> Reply
+```
+
+### Local sugerido do arquivo
+`apps/api/src/plugins/error-handler.plugin.ts` (plugin/factory que registra o setErrorHandler durante o bootstrap)
+
+### Pseudo-código ilustrativo
+```typescript
+// Pseudo-código ilustrativo — não é código de produção
+// apps/api/src/plugins/error-handler.plugin.ts
+
+// Mapa de erros de domínio → HTTP
+const errorMap = {
+  ProductNotFoundException: { statusCode: 404, error: 'ProductNotFoundException', message: 'Produto não encontrado' },
+  InsufficientStockError:   { statusCode: 400, error: 'InsufficientStockError', message: 'Estoque insuficiente para o produto {nome}' },
+  CategoryNotFoundException: { statusCode: 404, error: 'CategoryNotFoundException', message: 'Categoria não encontrada' },
+  OrderNotFoundException: { statusCode: 404, error: 'OrderNotFoundException', message: 'Pedido não encontrado' },
+};
+
+fastify.setErrorHandler((error, request, reply) => {
+  // Caso 1: Erro de Domínio mapeado
+  if (error instanceof DomainError) {
+    const meta = errorMap[error.constructor.name];
+    if (meta) {
+      return reply.status(meta.statusCode).send({
+        error: meta.error,
+        message: meta.message.replace('{nome}', error.context?.name ?? ''),
+        details: error.context?.details ?? undefined,
+      });
+    }
+  }
+
+  // Caso 2: Erro de Validação Zod
+  if (error.name === 'ZodError' /* instanceof ZodError */) {
+    return reply.status(400).send({
+      error: 'ValidationError',
+      message: 'Dados inválidos',
+      details: error.issues, // array de issues do Zod
+    });
+  }
+
+  // Caso 3: Erro não mapeado — loga real, expõe genérico
+  request.log.error({ err: error }, 'Unhandled error');
+  return reply.status(500).send({
+    error: 'InternalServerError',
+    message: 'Erro interno do servidor',
+  });
+});
+```
+
+## Consequências
+
+### Positivas
+- Ponto único de mudança para tratamento de erros, facilitando manutenção e auditoria.
+- Comportamento previsível e consistente para consumidores da API.
+- Facilidade de instrumentação (logs, métricas, Sentry) num único local.
+
+### Negativas / Trade-offs
+- A centralização exige disciplina: handlers de escopo/plugins adicionados sem convenção podem conflitar silenciosamente com o handler global.
+- Pode mascarar contexto específico do módulo se o DomainError não carregar dados de contexto suficientes.
+
+### Riscos e Dívida Técnica
+- Erros de terceiros (TypeORM, drivers, bibliotecas de rede) podem ter formatos inesperados — é necessário um fallback robusto e testes de integração que provoquem esses erros.
+- Se mensagens de usuário precisam ser internacionalizadas, o handler precisará integrar-se ao mecanismo de i18n (ver ADR-0001). Se for adicionado ad-hoc, pode gerar duplicação.
+
+## Alternativas Consideradas
+
+1. Handlers por escopo/plugin (ex.: register setErrorHandler em um plugin específico): descartado — aumenta fragmentação, duplicação e dificulta a auditoria central.
+2. try/catch manual em cada controller/route: descartado — muito repetitivo, propenso a inconsistências humanas e erros esquecidos.
+3. Middleware de erro estilo Express: não aplicável/indesejado — Fastify não usa o mesmo modelo de middleware de erro do Express; abordar via plugin/global handler é a prática recomendada.
+
+Outras opções breves avaliadas:
+- Usar um gateway API para normalizar respostas (externalizar responsabilidade): aumenta latência e complexidade operacional.
+- Event-driven retries/compensations: não resolve mapeamento HTTP de forma direta — complementar, não substituto.
+
+## Guia de Extensão Futura
+
+- Como adicionar um novo erro de domínio ao `errorMap` (passo a passo):
+  1. Criar a nova classe que estende `DomainError` em `libs/domain/src/errors` com nome e campos de contexto.
+  2. Adicionar uma entrada no `errorMap` em `apps/api/src/plugins/error-handler.plugin.ts` com `statusCode`, `error` e `message` (mensagem padrão em pt-BR; para i18n, ver ADR-0001).
+  3. Escrever testes de integração que lancem a exceção a partir do fluxo real e validem o JSON retornado.
+
+- Quando criar um handler de escopo:
+  - Cenário típico: integração de terceiros com payloads/erros proprietários (ex.: webhooks) ou requisitos locais de formato de resposta.
+  - Regras para não quebrar o global:
+    1. Scoped handlers só devem ser registrados se documentados no README do módulo e aprovados em PR de arquitetura.
+    2. Scoped handlers devem delegar para o handler global quando não reconheceram o erro (ex.: chamar reply.send ou lançar novamente).
+    3. Manter convenção de nomes de erro e herança de DomainError para permitir mapeamento central quando aplicável.
+
+- Evolução com i18n (referência ADR-0001):
+  - Substituir mensagens fixas no `errorMap` por chaves de recurso (ex.: `errorMessages.productNotFound`) e resolver a mensagem final no handler consultando o locale do request (Accept-Language / header da aplicação).
+  - Garantir fallback para pt-BR e testes que validem tanto chave quanto mensagem traduzida.
+
+## Referências
+- Fastify setErrorHandler — https://www.fastify.io/docs/latest/Reference/Server/#seterrorhandler
+- Zod — https://github.com/colinhacks/zod
+- ADR-0001 (i18n das mensagens): ../adr/0001-i18n.md
+
+## Verificação / Checklist
+1. Terminologia consistente: todos os termos usados (DomainError, ZodError, errorMap, handler global) aparecem no texto e diagramas — OK.
+2. Diagrama-texto parity: o mermaid flowchart descreve os 3 caminhos citados — OK.
+3. Exemplos de payloads/esquemas validam: pseudo-código usa campos declarados no texto (error, message, details) — OK.
+4. Plano de migração/rollback: documentado no Guia de Extensão Futura (passos para adicionar e testar) — OK, mas ver Observação abaixo.
+5. Segurança & Compliance: o handler não expõe stacks em produção; logs armazenam detalhes — ver Observação abaixo.
+6. Performance targets: nenhum target explícito fornecido pelo time — ASSUMPTION: handler deve adicionar <1ms overhead médio; necessidade de confirmação.
+
+Observações / Itens não resolvidos:
+- Target de performance e SLA não foram fornecidos — confirmar se existem requisitos de latência/throughput.
+- Nome/arquivo exato do ADR-0001 foi assumido como `0001-i18n.md`; ajustar se diferente.
+
+## Changelog
+- 2026-03-23: Criação do ADR-0002 — decisão por handler global centralizado. (autor: arquitetura)
+
+## TODO / Próximos Passos (com responsáveis e prioridade)
+- Implementar plugin `apps/api/src/plugins/error-handler.plugin.ts` com tests de integração — owner: Backend Team — prioridade: Alta
+- Adicionar entradas iniciais do errorMap (lista da tabela) — owner: Backend Team — prioridade: Alta
+- Adicionar testes de contrato que validem formato de erro para consumidores — owner: QA/Backend — prioridade: Média
+- Integrar messages → i18n conforme ADR-0001 — owner: Infra/Plat Team — prioridade: Média
+
+[⬆ Voltar para README](../../README.md)

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -2,6 +2,9 @@
 
 **Base URL**: `http://localhost:3000/api`
 
+> 💡 **Documentação Interativa**: Com o servidor rodando, acesse a UI do Swagger em [`http://localhost:3000/docs`](http://localhost:3000/docs).  
+> Para detalhes de configuração, veja [docs/openapi.md](openapi.md).
+
 ---
 
 ## 📂 Categories
@@ -495,6 +498,8 @@ Formato padrão de erros:
   ]
 }
 ```
+
+> ⚠️ **Tratamento de Erros**: Para o contrato completo de erros, hierarquia de exceções e como o handler global funciona, veja [docs/error-handling.md](error-handling.md).
 
 ### Status Codes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,16 @@ flowchart TD
 - Composição de comportamentos
 - Testabilidade unitária
 
+✅ **OpenAPI / Swagger**
+- Documentação de endpoints gerada automaticamente via `@fastify/swagger`
+- Schemas Zod convertidos para JSON Schema via `zod-to-json-schema`
+- UI interativa disponível em `/docs`
+
+✅ **Global Error Handler**
+- Handler centralizado via `setErrorHandler` do Fastify
+- Erros de domínio mapeados para HTTP via `errorMap` explícito
+- Detalhes em [docs/error-handling.md](error-handling.md)
+
 ---
 
 ## Benefícios da Arquitetura
@@ -200,6 +210,8 @@ graph TB
     style REPO fill:#96ceb4
     style DB fill:#ffeaa7
 ```
+
+> Nota: o Swagger Plugin (responsável por expor a UI em `/docs` e os specs JSON/YAML) faz parte da "Presentation Layer" e consome os Zod schemas para gerar a documentação interativa.
 
 ---
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,260 @@
+# ⚠️ Tratamento de Erros — Contrato e Mecanismo
+
+Scope: documentação técnica para engenheiros backend responsáveis por implementar e manter o handler global de erros na API Fastify.
+
+Resumo executivo
+-----------------
+Esta documentação descreve o contrato de erros da API (envelope), a classificação de exceções, a hierarquia de erros de domínio, o comportamento do handler global do Fastify e o fluxo desde o lançamento até a resposta HTTP. Segue as decisões registradas em [docs/adr/0001-idioma-mensagens-de-erro.md](adr/0001-idioma-mensagens-de-erro.md) e [docs/adr/0002-error-handler-centralizado.md](adr/0002-error-handler-centralizado.md).
+
+Objetivos
+---------
+- Definir um envelope de erro uniforme para todos os endpoints.
+- Mapear erros de domínio para códigos HTTP apropriados via um `errorMap` central.
+- Regras claras para erros de validação (Zod).
+- Orientar desenvolvedores sobre como adicionar novos erros de domínio.
+
+Não-goals
+--------
+- Não cobre implementação de i18n (fora do escopo; ver ADR-0001).
+- Não contém código de produção — apenas pseudo-código e exemplos de payload.
+
+Contexto e suposições
+---------------------
+- Projeto: Fastify + TypeScript em NX monorepo, DDD + Clean Architecture.
+- Mensagens legíveis ao usuário em pt-BR (ADR-0001). O campo `error` é um identificador em inglês.
+- Há um handler global via `fastify.setErrorHandler` (ADR-0002).
+- Assumo que os exemplos de payload em `docs/api-endpoints.md` são canônicos e devem ser reutilizados.
+
+1. Visão Geral
+---------------
+A API usa um error handler global centralizado no Fastify que classifica, formata e responde erros de forma uniforme em todos os endpoints. O handler traduz exceções do domínio e erros de validação em envelopes JSON padronizados e aplica o status HTTP apropriado. (Veja também ADR-0002 para a decisão arquitetural.)
+
+2. Envelope de Erro
+-------------------
+Definição dos dois formatos de resposta de erro suportados pelo handler:
+
+- Erros de negócio/infra (domínio + genérico)
+
+```json
+{
+  "error": "NomeDaExcecao",
+  "message": "Mensagem legível em português"
+}
+```
+
+- Erros de validação (Zod)
+
+```json
+{
+  "error": "ValidationError",
+  "message": "Dados inválidos",
+  "details": [
+    {
+      "field": "items[0].quantity",
+      "message": "Deve ser um número inteiro positivo"
+    }
+  ]
+}
+```
+
+Regras do envelope
+- `error`: sempre em inglês (identificador técnico — ex: `ProductNotFoundException`).
+- `message`: sempre em português (pt-BR) — texto legível para humanos conforme ADR-0001.
+- `details`: presente apenas em erros de validação; array com objetos { field, message }.
+- `statusCode` não é incluído no body — o código HTTP é enviado apenas no header.
+- Nenhum stack trace ou detalhe interno é exposto ao cliente em erros não mapeados.
+
+3. Classificação de Erros
+-------------------------
+O handler classifica erros em 3 categorias principais:
+
+| Categoria | Origem | Formato | Exemplo |
+|-----------|--------|---------|---------|
+| Erro de Domínio | `DomainError` (classe base) | `{ error, message }` | `ProductNotFoundException` |
+| Erro de Validação | `ZodError` | `{ error, message, details[] }` | Campos inválidos no body |
+| Erro Genérico | Qualquer outro | `{ error, message }` genérico | Erro inesperado de infra |
+
+4. Tabela de Erros de Domínio (primeira etapa)
+------------------------------------------------
+Tabela com as exceções de domínio mapeadas inicialmente:
+
+| Classe | HTTP Status | `error` | `message` |
+|--------|-------------|---------|-----------|
+| `ProductNotFoundException` | 404 | `ProductNotFoundException` | "Produto não encontrado" |
+| `CategoryNotFoundException` | 404 | `CategoryNotFoundException` | "Categoria não encontrada" |
+| `InsufficientStockError` | 400 | `InsufficientStockError` | "Estoque insuficiente para o produto {nome}" |
+| `OrderNotFoundException` | 404 | `OrderNotFoundException` | "Pedido não encontrado" |
+| `ZodError` | 400 | `ValidationError` | "Dados inválidos" |
+| Erro genérico | 500 | `InternalServerError` | "Erro interno do servidor" |
+
+Observação: mensagens devem usar templates quando apropriado (ex: incluir `{nome}`) e os valores concretos podem ser retornados apenas em campos documentados — evite expor dados sensíveis.
+
+5. Hierarquia de Erros de Domínio
+---------------------------------
+Exemplo em pseudo-código TypeScript ilustrativo (apenas para referência implementacional):
+
+```typescript
+// libs/domain/src/errors/
+// Pseudo-código ilustrativo
+
+// Classe base — todos os erros de domínio herdam desta
+class DomainError extends Error {
+  constructor(message: string) { ... }
+}
+
+// Erros concretos da primeira etapa
+class ProductNotFoundException extends DomainError { ... }
+class CategoryNotFoundException extends DomainError { ... }
+class InsufficientStockError extends DomainError {
+  // Carrega contexto adicional: nome do produto, disponível, solicitado
+}
+class OrderNotFoundException extends DomainError { ... }
+```
+
+Localização sugerida dos arquivos:
+
+```
+libs/domain/src/errors/
+├── domain.error.ts                  # Classe base
+├── product-not-found.error.ts
+├── category-not-found.error.ts
+├── insufficient-stock.error.ts
+└── order-not-found.error.ts
+```
+
+6. Como o Handler Global Funciona
+---------------------------------
+Diagrama do fluxo do erro desde o lançamento até a resposta HTTP:
+
+```mermaid
+flowchart TD
+    A[Exceção lançada em qualquer camada] --> B[Fastify captura via setErrorHandler]
+    B --> C{Tipo do erro?}
+    C -->|DomainError| D[Busca no errorMap]
+    D --> E[Responde com statusCode + envelope mapeado]
+    C -->|ZodError| F[Formata details por campo]
+    F --> G[Responde 400 + envelope com details]
+    C -->|Outro| H[Loga mensagem real internamente]
+    H --> I[Responde 500 com mensagem genérica]
+```
+
+Explicação dos caminhos
+- DomainError: o handler consulta um `errorMap` que mapeia a classe do erro para status HTTP, `error` (nome) e `message` (pt-BR). Retorna o envelope sem stack trace.
+- ZodError: transforma `ZodError.issues` em `details: [{ field, message }]` e responde com `400` e `error: ValidationError`.
+- Outro (não mapeado): o handler faz logging com nível `error` e inclui stack trace nos logs internos via `request.log.error(err)`; a resposta ao cliente é `500` com `InternalServerError` e mensagem genérica.
+
+7. Exemplos de Resposta por Cenário
+----------------------------------
+Usamos os exemplos presentes em `docs/api-endpoints.md` quando aplicável.
+
+Produto não encontrado (404)
+
+Request:
+```http
+GET /api/products/00000000-0000-0000-0000-000000000000
+```
+
+Response 404:
+```json
+{
+  "error": "ProductNotFoundException",
+  "message": "Produto não encontrado"
+}
+```
+
+Estoque insuficiente (400)
+
+Request (criar pedido):
+```json
+{
+  "items": [
+    { "productId": "323e4567-e89b-12d3-a456-426614174002", "quantity": 2 }
+  ]
+}
+```
+
+Response 400:
+```json
+{
+  "error": "InsufficientStockError",
+  "message": "Estoque insuficiente para o produto Coca-Cola 2L"
+}
+```
+
+Validação de input (400 com details)
+
+Request (criar pedido com body vazio):
+```json
+{}
+```
+
+Response 400:
+```json
+{
+  "error": "ValidationError",
+  "message": "Dados inválidos",
+  "details": [
+    { "field": "items", "message": "items must contain at least 1 item" }
+  ]
+}
+```
+
+Erro interno (500)
+
+Request: qualquer request que provoque um erro não mapeado (ex: falha de infra inesperada)
+
+Response 500:
+```json
+{
+  "error": "InternalServerError",
+  "message": "Erro interno do servidor"
+}
+```
+
+8. Como Adicionar um Novo Erro de Domínio
+-----------------------------------------
+Passos que um desenvolvedor deve seguir:
+
+1. Criar a classe em `libs/domain/src/errors/` herdando de `DomainError`.
+2. Definir a mensagem em português no construtor (usar mensagens centralizadas quando possível).
+3. Adicionar a entrada no `errorMap` em `apps/api/src/plugins/error-handler.plugin.ts` (mapeie status, `error` e `message`).
+4. Documentar a nova exceção na tabela da seção 4 deste documento (atualizar versão/changelog).
+
+9. Logging de Erros
+-------------------
+- Erros de domínio mapeados: não são logados (fluxos esperados). Caso queira contexto, usar `request.log.debug` opcionalmente.
+- Erros de validação: não são logados (são responsabilidade do cliente).
+- Erros não mapeados: são logados com nível `error` usando `request.log.error(err)` e incluem stack trace interno — porém **nunca** expostos na response.
+
+Recomendações práticas
+- Incluir identificadores correlacionados (ex: requestId) em logs para rastreabilidade.
+- Emitir métricas: contador de erros por tipo (mapped / validation / generic) e latência/time-to-first-error.
+
+10. Referências e ADRs
+---------------------
+- ADR-0001: [docs/adr/0001-idioma-mensagens-de-erro.md](adr/0001-idioma-mensagens-de-erro.md)
+- ADR-0002: [docs/adr/0002-error-handler-centralizado.md](adr/0002-error-handler-centralizado.md)
+- Exemplos de endpoints: [docs/api-endpoints.md](api-endpoints.md)
+
+Verification checklist
+----------------------
+1. Terminologia consistente: verifique que `DomainError`, `ValidationError`, `InternalServerError` aparecem nos diagramas e no texto (PASS)
+2. Diagram-text parity: todos os componentes do diagrama estão descritos (PASS)
+3. Schema examples validate: exemplos seguem os shapes declarados (PASS)
+4. Migration plan completeness: instruções para adicionar novos erros incluídas (PASS)
+5. Security & compliance: authz/authn não afetados; evitar exposição de dados sensíveis (PASS)
+6. Performance targets: assumir throughput médio; recomendo monitorar erros por tipo (TODO: adicionar metas específicas)
+
+Remediações / Assunções não resolvidas
+- Adicionar metas de performance e SLOs (assumidas fora do escopo atual) — AÇÃO: definir com SRE/Product.
+
+Changelog
+---------
+- 2026-03-23: Criação inicial do documento com contrato de erros, exemplos e instruções de implementação.
+
+TODO / Ações
+-----------
+- [ ] Adicionar validação automática de schemas de erro em CI (owner: infra eng, prioridade: medium)
+- [ ] Implementar métricas e dashboards para erro-métricas (owner: SRE, prioridade: medium)
+
+[⬆ Voltar para README](../README.md)

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,0 +1,321 @@
+# 📐 OpenAPI / Swagger
+
+## Escopo
+
+Este documento descreve a adoção do OpenAPI (Swagger) no projeto Common Cornershop: bibliotecas recomendadas, instalação, configuração no Fastify, integração com os Zod schemas já existentes, convenções de tags e boas práticas para manter a documentação como fonte confiável da API.
+
+Resumo executivo
+- Objetivo: gerar e servir automaticamente a especificação OpenAPI 3.0 e uma UI interativa (Swagger UI) baseada nos Zod schemas já existentes.
+- Público: engenheiros backend, devs responsáveis pelas rotas e reviewers de PR.
+
+---
+
+## 🎯 Goals e Non-goals
+
+Goals
+- Fornecer instruções claras para usar OpenAPI no Fastify com os schemas Zod existentes
+- Garantir que a documentação seja gerada automaticamente e acessível em /docs
+- Definir convenções mínimas para metadados e tags
+
+Non-goals
+- Não incluir código de produção definitivo (apenas exemplos ilustrativos)
+- Não cobrir autenticação avançada ou geração automática de clients (pode ser futuro)
+
+---
+
+## 📚 Bibliotecas recomendadas
+
+| Biblioteca | Papel |
+|-----------:|:-----|
+| `@fastify/swagger` | Gera o spec OpenAPI 3.0 a partir das rotas Fastify e dos schemas declarados nas rotas. |
+| `@fastify/swagger-ui` | Serve uma interface interativa (Swagger UI) para explorar e testar a API em /docs. |
+| `zod-to-json-schema` | Converte Zod schemas (nosso fonte da verdade) em JSON Schema compatível com OpenAPI, evitando duplicação de validações. |
+
+Breve explicação
+- @fastify/swagger: responsável por compilar os metadados (schema, tags, summary, responses) expostos nas rotas e montar o spec JSON/YAML.
+- @fastify/swagger-ui: serve os assets do Swagger UI e mapeia a rota /docs para a interface interativa.
+- zod-to-json-schema: mantém Zod como fonte da verdade — converte Zod → JSON Schema para ser referenciado nas rotas Fastify.
+
+---
+
+## ⚙️ Instalação
+
+Instale as dependências com yarn:
+
+```bash
+# Instala bibliotecas necessárias para gerar e servir OpenAPI/Swagger
+yarn add @fastify/swagger @fastify/swagger-ui zod-to-json-schema
+```
+
+---
+
+## 🔌 Configuração do plugin no Fastify (exemplo ilustrativo)
+
+Arquivo sugerido: `apps/api/src/plugins/swagger.plugin.ts`
+
+Exemplo (pseudo-código TypeScript-like):
+
+```typescript
+// apps/api/src/plugins/swagger.plugin.ts
+// Pseudo-código ilustrativo — não código de produção
+import fastify from 'fastify';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+
+export const registerSwagger = async (app: FastifyInstance) => {
+  // Registra gerador do spec OpenAPI
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: 'Common Cornershop API',       // título da API
+        description: 'API REST para gestão de lojas de esquina',
+        version: '1.0.0'                      // versão da API (sincronizar com package.json se possível)
+      },
+      servers: [
+        { url: 'http://localhost:3000', description: 'Local'}
+      ]
+    },
+    // Opcional: personalizações do schema
+    // hideUntagged: false, // mostrar rotas sem tags
+  });
+
+  // Registra UI em /docs (rota estática para Swagger UI)
+  await app.register(swaggerUi, {
+    routePrefix: '/docs', // UI disponível em /docs
+    uiConfig: {
+      docExpansion: 'list',
+      deepLinking: false
+    },
+    // url: '/docs/json' // (opcional) endpoint do spec
+  });
+};
+
+// No bootstrap da aplicação (ex: apps/api/src/server.ts) -> registerSwagger(app)
+```
+
+Notas
+- O Fastify expõe automaticamente endpoints auxiliares (dependendo da configuração): um JSON spec (/docs/json) e um YAML spec (/docs/yaml) além da UI em /docs.
+- Mantenha title/description/version atualizados; use CI para garantir version bumps.
+
+---
+
+## 🔗 Integração com Zod schemas existentes
+
+Objetivo: evitar duplicação — manter Zod como fonte da verdade e converter para JSON Schema quando necessário.
+
+Fluxo recomendado (ilustrativo)
+
+1. Mantenha os Zod schemas dentro de `apps/api/src/schemas/` (já existente no projeto).
+2. No registro da rota Fastify, converta os schemas Zod para JSON Schema usando `zodToJsonSchema` e passe o resultado para a propriedade `schema` da rota: { body, querystring, params, response }.
+
+Exemplo (pseudo-código) — schema de criação de pedidos
+
+```typescript
+// apps/api/src/schemas/order.schemas.ts
+import { z } from 'zod';
+
+export const createOrderSchema = z.object({
+  items: z.array(
+    z.object({
+      productId: z.string().uuid(),
+      quantity: z.number().int().positive()
+    })
+  ).min(1)
+});
+
+// Em uma rota Fastify (pseudo-código):
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { createOrderSchema } from '../schemas/order.schemas';
+
+const createOrderJsonSchema = zodToJsonSchema(createOrderSchema, 'CreateOrder');
+
+fastify.post('/api/orders', {
+  schema: {
+    // Converte e injeta o JSON Schema no Fastify
+    body: createOrderJsonSchema,
+    response: {
+      201: {
+        // Exemplo de response schema — também pode ser gerado a partir de Zod
+        type: 'object',
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          orderNumber: { type: 'string' },
+          status: { type: 'string' },
+          totalAmount: { type: 'number' }
+        }
+      }
+    }
+  },
+  handler: async (request, reply) => {
+    // handler -> usa UseCases, Services, etc.
+  }
+});
+
+// Comentário: preferir gerar também o schema de resposta via Zod quando possível
+```
+
+Observações
+- Nem todas as propriedades Zod são automaticamente convertidas com metadados OpenAPI (por exemplo: descrições). Pode-se enriquecer o JSON Schema manualmente após conversão.
+- Para evitar erros de tipos, adicione sempre 'title' no zodToJsonSchema (ex: 'CreateOrder') para identificar componentes.
+
+---
+
+## 🏷️ Anotando rotas com metadados OpenAPI
+
+Para gerar documentação útil, as rotas devem conter metadados: tags, summary, description e operationId.
+
+Exemplo ilustrativo por grupo de endpoints:
+
+Categories
+
+```typescript
+fastify.get('/api/categories', {
+  schema: {
+    tags: ['Categories'],
+    summary: 'Lista categorias',
+    description: 'Retorna lista paginada de categorias ativas',
+    operationId: 'listCategories',
+    querystring: {/* json schema gerado a partir de Zod */}
+  }
+}, handler);
+```
+
+Products
+
+```typescript
+fastify.get('/api/products/:id', {
+  schema: {
+    tags: ['Products'],
+    summary: 'Obter produto',
+    description: 'Retorna um produto por ID com informação de estoque',
+    operationId: 'getProductById',
+    params: {/* json schema */},
+    response: {/* json schema de resposta */}
+  }
+}, handler);
+```
+
+Orders
+
+```typescript
+fastify.post('/api/orders', {
+  schema: {
+    tags: ['Orders'],
+    summary: 'Criar pedido',
+    description: 'Cria um pedido com lista de itens e valida disponibilidade de estoque',
+    operationId: 'createOrder',
+    body: {/* json schema */},
+    response: { 201: {/* json schema */}, 400: {/* json schema */} }
+  }
+}, handler);
+```
+
+Recomendação
+- Padronize operationId como <verb><Resource><Qualifier?> (ex: createOrder, listProducts, getCategoryById).
+
+---
+
+## 🏷️ Convenção de Tags (padrões do projeto)
+
+- Categories
+- Products
+- Orders
+
+Use as tags exatamente como acima para manter a UI e os filtros consistentes.
+
+---
+
+## 🌐 Acesso à documentação
+
+Após a configuração, os endpoints padrões são:
+
+- Swagger UI: http://localhost:3000/docs
+- JSON Spec: http://localhost:3000/docs/json
+- YAML Spec: http://localhost:3000/docs/yaml
+
+Observação: dependendo da versão do @fastify/swagger as rotas exatas podem variar; confirme no plugin registrado.
+
+---
+
+## ✅ Boas práticas (project-specific)
+
+- Sempre adicionar `summary` e `description` nas rotas — ajudam usuários e geradores de cliente.
+- Usar `tags` consistentes com os módulos do projeto (Categories, Products, Orders).
+- Definir `response` schemas para todos os status codes documentados em `docs/api-endpoints.md` (200, 201, 400, 404, 500).
+- Manter os Zod schemas como fonte da verdade (evitar duplicação de validação). Use `zod-to-json-schema` para conversão.
+- Versionar a API no path quando houver breaking changes (ex: `/api/v1/...`).
+- Enriquecer os schemas com descrições e exemplos quando possível para melhorar a experiência na UI.
+
+---
+
+## ⚠️ Considerações de Segurança e Produção
+
+- Não exponha a UI do Swagger em produção sem autenticação — use feature flag ou proteção por IP/basic auth.
+- Remova ou proteja endpoints sensíveis (ex: administración) da UI pública.
+- Sanitizar e limitar exemplos de payloads que possam conter dados sensíveis.
+
+---
+
+## 🧭 Fluxo de alto nível (mermaid)
+
+```mermaid
+flowchart LR
+  Client[Cliente / Dev] -->|GET /docs| SwaggerUI[Swagger UI (/docs)]
+  Client -->|GET /docs/json| Spec[OpenAPI JSON]
+  Server[Fastify API] -->|@fastify/swagger| SwaggerPlugin[Swagger Plugin]
+  SwaggerPlugin --> Spec
+  Server -->|routes use Zod| Schemas[Zod Schemas]
+  Schemas -->|zod-to-json-schema| JSONSchema
+  JSONSchema --> SwaggerPlugin
+```
+
+---
+
+## 🔁 Versioning & Evolução de Schemas
+
+- Use semantic versioning na propriedade info.version do OpenAPI e versionamento via path quando quebra de contrato ocorrer.
+- Para evoluções não breaking, mantenha compatibilidade backward/forward: tornar campos opcionais invés de removê-los.
+- Para renome de campo ou alteração incompatible, ofereça um período de transição com ambas as versões (ex: /api/v1 e /api/v2) e um plano de migração para consumidores.
+
+---
+
+## ✅ Verificação / Checklist de Integração (para PRs)
+
+Antes de mesclar PRs que alterem rotas ou schemas, valide:
+
+1. Terminologia consistente: tags, operationId, nomes de schemas.
+2. Diagram-text parity: rotas novas aparecem no Swagger UI e no spec JSON/YAML.
+3. Schema examples: exemplos de payloads/response seguem o JSON Schema gerado.
+4. Migration plan: mudanças breaking têm plano de migração/feature toggle.
+5. Segurança: UI protegida em ambientes não-dev.
+6. Performance targets: confirm que geração do spec não impacta tempo de startup (monitorar).
+
+Se algum item falhar, inclua correção no PR ou reprove até ajustes.
+
+---
+
+## 🧪 Testes e Verificação Automática
+
+- Adicione um job de CI que inicie a aplicação (modo headless) e valide que `/docs/json` responde com 200 e é um JSON válido.
+- Contract tests: para consumidores internos, gere snapshot do spec e compare em PRs para detectar mudanças involuntárias.
+- Lint de schemas: verifique que todos os endpoints listados em `docs/api-endpoints.md` possuem metadados básicos (tags/summary/response).
+
+---
+
+## Migração e Rollout (resumo)
+
+1. Instalar dependências em branch feature
+2. Registrar plugin apenas em ambientes dev/staging inicialmente
+3. Converter alguns endpoints críticos usando zod-to-json-schema e validar UI
+4. Habilitar proteção na UI em produção (auth/feature flag)
+5. Comunicar consumidores sobre o spec e onde encontrar (links no README)
+
+---
+
+## Changelog
+
+- 2026-03-23: Documento inicial introduzindo configuração, integração com Zod e boas práticas.
+
+---
+
+[⬆ Voltar para README](../README.md)


### PR DESCRIPTION
## Resumo

Adiciona documentação completa para as decisões e contratos definidos na primeira etapa da API.

### O que foi adicionado

- **`docs/openapi.md`** — guia de configuração do `@fastify/swagger` + `@fastify/swagger-ui`, integração com Zod via `zod-to-json-schema`, convenções de tags e boas práticas
- **`docs/error-handling.md`** — contrato de erros da API: dois formatos de envelope (negócio vs. validação), tabela de mapeamento de domínio → HTTP, hierarquia de classes, fluxo do handler e passo a passo para adicionar novos erros
- **`docs/adr/0001-idioma-mensagens-de-erro.md`** — ADR: mensagens em pt-BR na primeira etapa, com plano de migração para i18n futuro (i18next)
- **`docs/adr/0002-error-handler-centralizado.md`** — ADR: `setErrorHandler` global e centralizado no Fastify, com guia de extensão futura

### O que foi atualizado

- `README.md` — links para os novos documentos e item "API Documentation" marcado como concluído
- `docs/architecture.md` — padrões OpenAPI/Swagger e Global Error Handler adicionados
- `docs/api-endpoints.md` — referências para Swagger UI e `error-handling.md`

## Checklist

- [x] Toda documentação em pt-BR
- [x] Nenhum código de produção — apenas pseudo-código ilustrativo
- [x] ADRs com status, alternativas consideradas e plano de evolução
- [x] Contrato de erros com tabela de mapeamento completa para a primeira etapa
- [x] Links internos entre documentos validados