### PR TITLE
test(api): add T5.5 e2e flows with fixtures and factories

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -1,6 +1,7 @@
 export default {
   displayName: 'api',
   preset: '../../jest.preset.js',
+  testMatch: ['<rootDir>/src/**/*.spec.ts', '<rootDir>/src/**/*.e2e-spec.ts'],
   testEnvironment: 'node',
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/apps/api/src/test/e2e/core-flows.e2e-spec.ts
+++ b/apps/api/src/test/e2e/core-flows.e2e-spec.ts
@@ -1,0 +1,262 @@
+import { FastifyInstance } from 'fastify';
+
+import { Stock } from '../../../../../libs/domain/src/entities/stock.entity';
+
+import { AppDataSource } from '../../database/data-source';
+
+import { OrderFactory } from './factories/order.factory';
+import { E2ETestSetup } from './setup';
+
+describe('API E2E - core flows with fixtures/factories', () => {
+  let app: FastifyInstance;
+  const e2e = new E2ETestSetup();
+
+  beforeAll(async () => {
+    app = await e2e.init();
+  });
+
+  beforeEach(async () => {
+    await e2e.resetState();
+  });
+
+  afterAll(async () => {
+    await e2e.teardown();
+  });
+
+  it('should execute full happy path: list categories/products, create order and fetch order', async () => {
+    // Arrange
+    const category = await e2e.fixtures.createCategory({
+      name: 'Bebidas',
+      description: 'Refrigerantes e sucos',
+    });
+
+    const cola = await e2e.fixtures.createProductWithStock({
+      categoryId: category.id,
+      name: 'Coca-Cola 2L',
+      price: 8.5,
+      stockQuantity: 10,
+      minimumQuantity: 2,
+    });
+
+    const guarana = await e2e.fixtures.createProductWithStock({
+      categoryId: category.id,
+      name: 'Guaraná 2L',
+      price: 7.5,
+      stockQuantity: 7,
+      minimumQuantity: 1,
+    });
+
+    // Act - categories
+    const listCategoriesResponse = await app.inject({
+      method: 'GET',
+      url: '/api/categories?page=1&limit=10',
+    });
+
+    // Assert - categories contract
+    expect(listCategoriesResponse.statusCode).toBe(200);
+    expect(listCategoriesResponse.json()).toEqual({
+      data: [
+        expect.objectContaining({
+          id: category.id,
+          name: 'Bebidas',
+          description: 'Refrigerantes e sucos',
+          isActive: true,
+        }),
+      ],
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      },
+    });
+
+    // Act - products
+    const listProductsResponse = await app.inject({
+      method: 'GET',
+      url: `/api/products?page=1&limit=10&categoryId=${category.id}&isActive=true`,
+    });
+
+    // Assert - products contract
+    expect(listProductsResponse.statusCode).toBe(200);
+    expect(listProductsResponse.json()).toEqual({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          id: cola.product.id,
+          name: 'Coca-Cola 2L',
+          price: 8.5,
+          categoryId: category.id,
+        }),
+        expect.objectContaining({
+          id: guarana.product.id,
+          name: 'Guaraná 2L',
+          price: 7.5,
+          categoryId: category.id,
+        }),
+      ]),
+      meta: {
+        page: 1,
+        limit: 10,
+        total: 2,
+        totalPages: 1,
+      },
+    });
+
+    // Act - create order
+    const createOrderResponse = await app.inject({
+      method: 'POST',
+      url: '/api/orders',
+      payload: OrderFactory.buildCreatePayload([
+        { productId: cola.product.id, quantity: 2 },
+        { productId: guarana.product.id, quantity: 1 },
+      ]),
+    });
+
+    // Assert - create order contract
+    expect(createOrderResponse.statusCode).toBe(201);
+    const createdOrder = createOrderResponse.json();
+
+    expect(createdOrder).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        orderNumber: expect.stringMatching(/^ORD-/),
+        status: 'PENDING',
+        totalAmount: 24.5,
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            productId: cola.product.id,
+            quantity: 2,
+            unitPrice: 8.5,
+            subtotal: 17,
+            product: expect.objectContaining({
+              id: cola.product.id,
+              name: 'Coca-Cola 2L',
+              price: 8.5,
+            }),
+          }),
+          expect.objectContaining({
+            productId: guarana.product.id,
+            quantity: 1,
+            unitPrice: 7.5,
+            subtotal: 7.5,
+            product: expect.objectContaining({
+              id: guarana.product.id,
+              name: 'Guaraná 2L',
+              price: 7.5,
+            }),
+          }),
+        ]),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      }),
+    );
+
+    // Act - get order by id
+    const getOrderResponse = await app.inject({
+      method: 'GET',
+      url: `/api/orders/${createdOrder.id}`,
+    });
+
+    // Assert - get order contract
+    expect(getOrderResponse.statusCode).toBe(200);
+    expect(getOrderResponse.json()).toEqual(
+      expect.objectContaining({
+        id: createdOrder.id,
+        orderNumber: createdOrder.orderNumber,
+        status: 'PENDING',
+        totalAmount: 24.5,
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            productId: cola.product.id,
+            quantity: 2,
+            unitPrice: 8.5,
+            subtotal: 17,
+            product: expect.objectContaining({
+              id: cola.product.id,
+              name: 'Coca-Cola 2L',
+            }),
+          }),
+          expect.objectContaining({
+            productId: guarana.product.id,
+            quantity: 1,
+            unitPrice: 7.5,
+            subtotal: 7.5,
+            product: expect.objectContaining({
+              id: guarana.product.id,
+              name: 'Guaraná 2L',
+            }),
+          }),
+        ]),
+      }),
+    );
+
+    // Assert - stock remains consistent (current behavior does not decrement on order creation)
+    const stockRepository = AppDataSource.getRepository(Stock);
+    const updatedColaStock = await stockRepository.findOne({
+      where: { productId: cola.product.id },
+    });
+    const updatedGuaranaStock = await stockRepository.findOne({
+      where: { productId: guarana.product.id },
+    });
+
+    expect(updatedColaStock?.quantity).toBe(10);
+    expect(updatedGuaranaStock?.quantity).toBe(7);
+  });
+
+  it('should return standardized validation contract for invalid product query', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/products?categoryId=invalid-uuid',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual(
+      expect.objectContaining({
+        error: 'ValidationError',
+        message: 'Dados inválidos',
+        details: expect.arrayContaining([
+          expect.objectContaining({
+            field: 'categoryId',
+            message: expect.any(String),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('should return standardized domain error when creating order with insufficient stock', async () => {
+    const category = await e2e.fixtures.createCategory({ name: 'Mercearia' });
+    const item = await e2e.fixtures.createProductWithStock({
+      categoryId: category.id,
+      name: 'Arroz 5kg',
+      price: 30,
+      stockQuantity: 1,
+      minimumQuantity: 0,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/orders',
+      payload: OrderFactory.buildCreatePayload([{ productId: item.product.id, quantity: 2 }]),
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: 'InsufficientStockError',
+      message: 'Estoque insuficiente',
+    });
+  });
+
+  it('should return standardized domain error when order is not found', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/orders/9f1f50a8-3df7-49ba-8397-f5fd027974db',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: 'OrderNotFoundException',
+      message: 'Pedido não encontrado',
+    });
+  });
+});

--- a/apps/api/src/test/e2e/factories/category.factory.ts
+++ b/apps/api/src/test/e2e/factories/category.factory.ts
@@ -1,0 +1,32 @@
+interface CategoryFactoryInput {
+  name?: string;
+  description?: string | null;
+  isActive?: boolean;
+}
+
+export interface CategorySeedData {
+  name: string;
+  description: string | null;
+  isActive: boolean;
+}
+
+/**
+ * Deterministic builder for category seed data used in E2E tests.
+ */
+export class CategoryFactory {
+  private static sequence = 1;
+
+  static reset(): void {
+    this.sequence = 1;
+  }
+
+  static build(input: CategoryFactoryInput = {}): CategorySeedData {
+    const seed = this.sequence++;
+
+    return {
+      name: input.name ?? `Categoria E2E ${seed}`,
+      description: input.description ?? `Descrição E2E ${seed}`,
+      isActive: input.isActive ?? true,
+    };
+  }
+}

--- a/apps/api/src/test/e2e/factories/order.factory.ts
+++ b/apps/api/src/test/e2e/factories/order.factory.ts
@@ -1,0 +1,27 @@
+interface OrderItemPayloadInput {
+  productId: string;
+  quantity?: number;
+}
+
+export interface OrderItemPayload {
+  productId: string;
+  quantity: number;
+}
+
+export interface CreateOrderPayload {
+  items: OrderItemPayload[];
+}
+
+/**
+ * Builder for order payloads used in E2E requests.
+ */
+export class OrderFactory {
+  static buildCreatePayload(items: OrderItemPayloadInput[]): CreateOrderPayload {
+    return {
+      items: items.map((item) => ({
+        productId: item.productId,
+        quantity: item.quantity ?? 1,
+      })),
+    };
+  }
+}

--- a/apps/api/src/test/e2e/factories/product.factory.ts
+++ b/apps/api/src/test/e2e/factories/product.factory.ts
@@ -1,0 +1,35 @@
+interface ProductFactoryInput {
+  name?: string;
+  description?: string | null;
+  price?: number;
+  isActive?: boolean;
+}
+
+export interface ProductSeedData {
+  name: string;
+  description: string | null;
+  price: number;
+  isActive: boolean;
+}
+
+/**
+ * Deterministic builder for product seed data used in E2E tests.
+ */
+export class ProductFactory {
+  private static sequence = 1;
+
+  static reset(): void {
+    this.sequence = 1;
+  }
+
+  static build(input: ProductFactoryInput = {}): ProductSeedData {
+    const seed = this.sequence++;
+
+    return {
+      name: input.name ?? `Produto E2E ${seed}`,
+      description: input.description ?? `Descrição produto E2E ${seed}`,
+      price: input.price ?? seed * 10,
+      isActive: input.isActive ?? true,
+    };
+  }
+}

--- a/apps/api/src/test/e2e/fixtures/e2e-fixtures.ts
+++ b/apps/api/src/test/e2e/fixtures/e2e-fixtures.ts
@@ -1,0 +1,95 @@
+import { DataSource, Repository } from 'typeorm';
+
+import { Category } from '@domain/entities/category.entity';
+import { Product } from '@domain/entities/product.entity';
+import { Stock } from '@domain/entities/stock.entity';
+
+import { CategoryFactory } from '../factories/category.factory';
+import { ProductFactory } from '../factories/product.factory';
+
+interface ProductFixtureInput {
+  categoryId: string;
+  name?: string;
+  description?: string | null;
+  price?: number;
+  isActive?: boolean;
+  stockQuantity?: number;
+  minimumQuantity?: number;
+}
+
+export interface ProductWithStockFixture {
+  product: Product;
+  stock: Stock;
+}
+
+/**
+ * Reusable fixture helpers for E2E tests.
+ */
+export class E2EFixtures {
+  private readonly categoryRepository: Repository<Category>;
+  private readonly productRepository: Repository<Product>;
+  private readonly stockRepository: Repository<Stock>;
+
+  constructor(private readonly dataSource: DataSource) {
+    this.categoryRepository = dataSource.getRepository(Category);
+    this.productRepository = dataSource.getRepository(Product);
+    this.stockRepository = dataSource.getRepository(Stock);
+  }
+
+  async clearDatabase(): Promise<void> {
+    await this.dataSource.query(
+      'TRUNCATE TABLE "order_items", "orders", "stocks", "products", "categories" RESTART IDENTITY CASCADE',
+    );
+  }
+
+  resetFactories(): void {
+    CategoryFactory.reset();
+    ProductFactory.reset();
+  }
+
+  async createCategory(overrides: Partial<Category> = {}): Promise<Category> {
+    const base = CategoryFactory.build({
+      name: overrides.name,
+      description: overrides.description,
+      isActive: overrides.isActive,
+    });
+
+    const categoryToCreate = this.categoryRepository.create({
+      name: base.name,
+      description: base.description ?? undefined,
+      isActive: base.isActive,
+    });
+
+    return this.categoryRepository.save(categoryToCreate);
+  }
+
+  async createProductWithStock(input: ProductFixtureInput): Promise<ProductWithStockFixture> {
+    const productBase = ProductFactory.build({
+      name: input.name,
+      description: input.description,
+      price: input.price,
+      isActive: input.isActive,
+    });
+
+    const productToCreate = this.productRepository.create({
+      name: productBase.name,
+      description: productBase.description ?? undefined,
+      price: productBase.price,
+      isActive: productBase.isActive,
+      categoryId: input.categoryId,
+    });
+
+    const product = await this.productRepository.save(productToCreate);
+
+    const stock = await this.stockRepository.save(
+      this.stockRepository.create({
+        productId: product.id,
+        quantity: input.stockQuantity ?? 10,
+        minimumQuantity: input.minimumQuantity ?? 1,
+        lastUpdatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    return { product, stock };
+  }
+}

--- a/apps/api/src/test/e2e/setup.ts
+++ b/apps/api/src/test/e2e/setup.ts
@@ -1,0 +1,137 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import { container } from 'tsyringe';
+
+import { CategoryController } from '../../controllers/category.controller';
+import { ProductController } from '../../controllers/product.controller';
+import { registerDependencies } from '../../container/dependency-injection';
+import { AppDataSource } from '../../database/data-source';
+import { OrderController } from '../../http/controllers/order.controller';
+import { registerErrorHandler } from '../../plugins/error-handler.plugin';
+import { Product } from '../../../../../libs/domain/src/entities/product.entity';
+import {
+  CancelOrderUseCase,
+  CreateOrderUseCase,
+  GetOrderUseCase,
+  ListOrdersUseCase,
+  UpdateOrderStatusUseCase,
+} from '../../../../../libs/domain/src';
+import { CategoryRepositoryImpl } from '../../repositories/category.repository.impl';
+import { OrderItemRepositoryImpl } from '../../repositories/order-item.repository.impl';
+import { OrderRepositoryImpl } from '../../repositories/order.repository.impl';
+import { ProductRepositoryImpl } from '../../repositories/product.repository.impl';
+import { StockRepositoryImpl } from '../../repositories/stock.repository.impl';
+
+import { E2EFixtures } from './fixtures/e2e-fixtures';
+
+const DEFAULT_TEST_DB_ENV = {
+  DB_HOST: 'localhost',
+  DB_PORT: '5432',
+  DB_USER: 'postgres',
+  DB_PASSWORD: 'postgres',
+  DB_NAME: 'cornershop_test',
+  DB_SSL: 'false',
+  DB_SSL_REJECT_UNAUTHORIZED: 'true',
+};
+
+/**
+ * Centralized bootstrapping for E2E tests.
+ */
+export class E2ETestSetup {
+  private app: FastifyInstance | null = null;
+
+  readonly fixtures = new E2EFixtures(AppDataSource);
+
+  async init(): Promise<FastifyInstance> {
+    this.applyTestDatabaseEnvironment();
+
+    if (!AppDataSource.isInitialized) {
+      await AppDataSource.initialize();
+      await AppDataSource.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+      await AppDataSource.synchronize(true);
+    }
+
+    registerDependencies();
+
+    container.register('ICategoryRepository', {
+      useFactory: () => new CategoryRepositoryImpl(AppDataSource),
+    });
+    container.register('IProductRepository', {
+      useFactory: () => new ProductRepositoryImpl(AppDataSource.getRepository(Product)),
+    });
+    container.register('IStockRepository', {
+      useFactory: () => new StockRepositoryImpl(AppDataSource),
+    });
+    container.register('IOrderRepository', {
+      useFactory: () => new OrderRepositoryImpl(AppDataSource),
+    });
+    container.register('IOrderItemRepository', {
+      useFactory: () => new OrderItemRepositoryImpl(AppDataSource),
+    });
+
+    this.app = Fastify({ logger: false });
+    registerErrorHandler(this.app);
+
+    const categoryController = container.resolve(CategoryController);
+    this.app.get('/api/categories', categoryController.list.bind(categoryController));
+    this.app.get('/api/categories/:id', categoryController.getById.bind(categoryController));
+
+    const productController = container.resolve(ProductController);
+    this.app.get('/api/products', productController.list.bind(productController));
+    this.app.get('/api/products/:id', productController.getById.bind(productController));
+
+    const orderController = new OrderController(
+      container.resolve(CreateOrderUseCase),
+      container.resolve(GetOrderUseCase),
+      container.resolve(ListOrdersUseCase),
+      container.resolve(UpdateOrderStatusUseCase),
+      container.resolve(CancelOrderUseCase),
+    );
+
+    this.app.post('/api/orders', orderController.create.bind(orderController));
+    this.app.get('/api/orders', orderController.list.bind(orderController));
+    this.app.get('/api/orders/:id', orderController.getById.bind(orderController));
+    this.app.get('/api/orders/:id/status', orderController.getStatus.bind(orderController));
+    this.app.patch('/api/orders/:id/status', orderController.updateStatus.bind(orderController));
+    this.app.patch('/api/orders/:id/cancel', orderController.cancel.bind(orderController));
+
+    await this.app.ready();
+
+    return this.app;
+  }
+
+  async resetState(): Promise<void> {
+    this.fixtures.resetFactories();
+    await this.fixtures.clearDatabase();
+  }
+
+  async teardown(): Promise<void> {
+    if (this.app) {
+      await this.app.close();
+      this.app = null;
+    }
+
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy();
+    }
+  }
+
+  private applyTestDatabaseEnvironment(): void {
+    process.env.NODE_ENV = 'test';
+    process.env.DB_HOST =
+      process.env.TEST_DB_HOST ?? process.env.DB_HOST ?? DEFAULT_TEST_DB_ENV.DB_HOST;
+    process.env.DB_PORT =
+      process.env.TEST_DB_PORT ?? process.env.DB_PORT ?? DEFAULT_TEST_DB_ENV.DB_PORT;
+    process.env.DB_USER =
+      process.env.TEST_DB_USER ?? process.env.DB_USER ?? DEFAULT_TEST_DB_ENV.DB_USER;
+    process.env.DB_PASSWORD =
+      process.env.TEST_DB_PASSWORD ?? process.env.DB_PASSWORD ?? DEFAULT_TEST_DB_ENV.DB_PASSWORD;
+    process.env.DB_NAME =
+      process.env.TEST_DB_NAME ??
+      process.env.DB_NAME_TEST ??
+      process.env.DB_NAME ??
+      DEFAULT_TEST_DB_ENV.DB_NAME;
+    process.env.DB_SSL = process.env.DB_SSL ?? DEFAULT_TEST_DB_ENV.DB_SSL;
+    process.env.DB_SSL_REJECT_UNAUTHORIZED =
+      process.env.DB_SSL_REJECT_UNAUTHORIZED ?? DEFAULT_TEST_DB_ENV.DB_SSL_REJECT_UNAUTHORIZED;
+  }
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -257,6 +257,7 @@ gantt
 - T2.5: entregue na branch `feat/T2.5-order-usecases` — OrderService, InvalidOrderStatusTransitionError e 5 UseCases (Create, Get, List, UpdateStatus, Cancel) com 37 novos testes unitários.
 - T3.2: entregue na branch `feat/T3.2-database-migrations` — 5 migrations TypeORM (categories → products → stocks → orders → order_items) com FKs, índices e check constraints.
 - T5.1 / T5.2: Unit tests para Services e UseCases implementados e com cobertura alinhada às metas (ver docs/testing.md). ✅ Concluído.
+- T5.5: E2E tests, fixtures e factories foram implementados na branch `feature/T5.5-e2e-tests-fixtures-factories` (commit `afaaea3`). Estes testes estão entregues nesta branch e aguardam merge para entrarem na main. ✅ Entregue (branch)
 
 - T4.4: entregue e mergeado (PR #58). ✅ Concluído.
 - T4.5: entregue e mergeado (PR #59). ✅ Concluído.
@@ -267,7 +268,7 @@ Nota de status geral:
 
 - Fase 2 (Core Domain & DB) está agora marcada como CONCLUÍDA — inclui migrations (T3.2) e seeds idempotentes (T3.3).
 - Fase 3 (API Layer) está agora marcada como CONCLUÍDA — T4.1..T4.6 foram entregues (controllers e rotas incluídos). Completamos também a camada de schemas (T4.2) e as implementações de repositório (T4.3).
-- Fase 4 (Quality) permanece em andamento: T5.1,T5.2,T5.3 concluídas; T5.4 e T5.5 ainda não iniciadas.
+- Fase 4 (Quality) permanece em andamento: T5.1, T5.2, T5.3, T5.4 concluídas; T5.5 entregue na branch `feature/T5.5-e2e-tests-fixtures-factories` (aguardando merge).
 
 Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (testes unitários com cobertura) são marcos já entregues.
 
@@ -290,13 +291,13 @@ Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (t
 
 - Objetivo: garantir cobertura de testes nas camadas críticas e integrar testes E2E.
 
-| ID   | Issue |                                                     Título | Estimativa | Prioridade | Status          | Link                                                         |
-| ---- | ----- | ---------------------------------------------------------: | ---------: | ---------- | --------------- | ------------------------------------------------------------ |
-| T5.1 | #18   |                       Testes — Unit Tests: Domain Services |         4h | Média      | ✅ Concluído    | [#18](https://github.com/Vandrs/common-cornershop/issues/18) |
-| T5.2 | #19   |                    Testes — Unit Tests: UseCases com mocks |         4h | Média      | ✅ Concluído    | [#19](https://github.com/Vandrs/common-cornershop/issues/19) |
-| T5.3 | #20   |     Testes — Integration Tests: Repository Implementations |         4h | Média      | ✅ Concluído    | [#20](https://github.com/Vandrs/common-cornershop/issues/20) |
-| T5.4 | #21   | Testes — Integration Tests: Controllers com Fastify inject |         4h | Média      | ⬜ Não iniciado | [#21](https://github.com/Vandrs/common-cornershop/issues/21) |
-| T5.5 | #22   |                   Testes — E2E Tests, Fixtures e Factories |         5h | Baixa      | ⬜ Não iniciado | [#22](https://github.com/Vandrs/common-cornershop/issues/22) |
+| ID   | Issue |                                                     Título | Estimativa | Prioridade | Status                                                                              | Link                                                         |
+| ---- | ----- | ---------------------------------------------------------: | ---------: | ---------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| T5.1 | #18   |                       Testes — Unit Tests: Domain Services |         4h | Média      | ✅ Concluído                                                                        | [#18](https://github.com/Vandrs/common-cornershop/issues/18) |
+| T5.2 | #19   |                    Testes — Unit Tests: UseCases com mocks |         4h | Média      | ✅ Concluído                                                                        | [#19](https://github.com/Vandrs/common-cornershop/issues/19) |
+| T5.3 | #20   |     Testes — Integration Tests: Repository Implementations |         4h | Média      | ✅ Concluído                                                                        | [#20](https://github.com/Vandrs/common-cornershop/issues/20) |
+| T5.4 | #21   | Testes — Integration Tests: Controllers com Fastify inject |         4h | Média      | ✅ Concluído (PR #62)                                                               | [#21](https://github.com/Vandrs/common-cornershop/issues/21) |
+| T5.5 | #22   |                   Testes — E2E Tests, Fixtures e Factories |         5h | Baixa      | ✅ Entregue (branch `feature/T5.5-e2e-tests-fixtures-factories` — aguardando merge) | [#22](https://github.com/Vandrs/common-cornershop/issues/22) |
 
 - Critério de conclusão: `yarn test` verde; E2E básicos passando contra docker-compose; cobertura mínima nas services e usecases.
 


### PR DESCRIPTION
## Summary
- implementa a T5.5 com testes E2E para fluxos centrais (categories, products e orders), incluindo happy path e falhas representativas
- adiciona fixtures e factories reutilizáveis para reduzir duplicação e tornar os cenários determinísticos
- sincroniza `docs/roadmap.md` com o status atual: T5.4 concluída (PR #62) e T5.5 entregue nesta branch aguardando merge

## Validation
- yarn test:e2e

## Scope
- T5.5 (#22)