### PR TITLE
docs(roadmap): sync T5.5 and set T6.2 on hold

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap — Common Cornershop 📍
 
 Data de criação: 2026-03-25
-Última atualização: 2026-04-02
+Última atualização: 2026-04-17
 
 GitHub Project: https://github.com/users/Vandrs/projects/2
 
@@ -33,8 +33,8 @@ O documento define as tasks, dependências, paralelismos e critérios de conclus
 | Fase 1 — Fundação         | Semana 1         | ✅ Concluída |
 | Fase 2 — Core Domain & DB | Semana 1–2       | ✅ Concluída |
 | Fase 3 — API Layer        | Semana 2–3       | ✅ Concluída |
-| Fase 4 — Quality          | Semana 3–4       | Em andamento |
-| Fase 5 — DevOps Final     | Semana 4         | Não iniciado |
+| Fase 4 — Quality          | Semana 3–4       | ✅ Concluída |
+| Fase 5 — DevOps Final     | Semana 4         | ⏸️ Em espera |
 
 ---
 
@@ -257,7 +257,7 @@ gantt
 - T2.5: entregue na branch `feat/T2.5-order-usecases` — OrderService, InvalidOrderStatusTransitionError e 5 UseCases (Create, Get, List, UpdateStatus, Cancel) com 37 novos testes unitários.
 - T3.2: entregue na branch `feat/T3.2-database-migrations` — 5 migrations TypeORM (categories → products → stocks → orders → order_items) com FKs, índices e check constraints.
 - T5.1 / T5.2: Unit tests para Services e UseCases implementados e com cobertura alinhada às metas (ver docs/testing.md). ✅ Concluído.
-- T5.5: E2E tests, fixtures e factories foram implementados na branch `feature/T5.5-e2e-tests-fixtures-factories` (commit `afaaea3`). Estes testes estão entregues nesta branch e aguardam merge para entrarem na main. ✅ Entregue (branch)
+- T5.5: E2E tests, fixtures e factories foram mergeados para a main (PR #63). ✅ Concluído (PR #63)
 
 - T4.4: entregue e mergeado (PR #58). ✅ Concluído.
 - T4.5: entregue e mergeado (PR #59). ✅ Concluído.
@@ -268,7 +268,7 @@ Nota de status geral:
 
 - Fase 2 (Core Domain & DB) está agora marcada como CONCLUÍDA — inclui migrations (T3.2) e seeds idempotentes (T3.3).
 - Fase 3 (API Layer) está agora marcada como CONCLUÍDA — T4.1..T4.6 foram entregues (controllers e rotas incluídos). Completamos também a camada de schemas (T4.2) e as implementações de repositório (T4.3).
-- Fase 4 (Quality) permanece em andamento: T5.1, T5.2, T5.3, T5.4 concluídas; T5.5 entregue na branch `feature/T5.5-e2e-tests-fixtures-factories` (aguardando merge).
+- Fase 4 (Quality) está agora marcada como CONCLUÍDA — todos os testes, incluindo E2E (T5.5), foram mergeados (PR #63).
 
 Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (testes unitários com cobertura) são marcos já entregues.
 
@@ -291,13 +291,13 @@ Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (t
 
 - Objetivo: garantir cobertura de testes nas camadas críticas e integrar testes E2E.
 
-| ID   | Issue |                                                     Título | Estimativa | Prioridade | Status                                                                              | Link                                                         |
-| ---- | ----- | ---------------------------------------------------------: | ---------: | ---------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| T5.1 | #18   |                       Testes — Unit Tests: Domain Services |         4h | Média      | ✅ Concluído                                                                        | [#18](https://github.com/Vandrs/common-cornershop/issues/18) |
-| T5.2 | #19   |                    Testes — Unit Tests: UseCases com mocks |         4h | Média      | ✅ Concluído                                                                        | [#19](https://github.com/Vandrs/common-cornershop/issues/19) |
-| T5.3 | #20   |     Testes — Integration Tests: Repository Implementations |         4h | Média      | ✅ Concluído                                                                        | [#20](https://github.com/Vandrs/common-cornershop/issues/20) |
-| T5.4 | #21   | Testes — Integration Tests: Controllers com Fastify inject |         4h | Média      | ✅ Concluído (PR #62)                                                               | [#21](https://github.com/Vandrs/common-cornershop/issues/21) |
-| T5.5 | #22   |                   Testes — E2E Tests, Fixtures e Factories |         5h | Baixa      | ✅ Entregue (branch `feature/T5.5-e2e-tests-fixtures-factories` — aguardando merge) | [#22](https://github.com/Vandrs/common-cornershop/issues/22) |
+| ID   | Issue |                                                     Título | Estimativa | Prioridade | Status                | Link                                                         |
+| ---- | ----- | ---------------------------------------------------------: | ---------: | ---------- | --------------------- | ------------------------------------------------------------ |
+| T5.1 | #18   |                       Testes — Unit Tests: Domain Services |         4h | Média      | ✅ Concluído          | [#18](https://github.com/Vandrs/common-cornershop/issues/18) |
+| T5.2 | #19   |                    Testes — Unit Tests: UseCases com mocks |         4h | Média      | ✅ Concluído          | [#19](https://github.com/Vandrs/common-cornershop/issues/19) |
+| T5.3 | #20   |     Testes — Integration Tests: Repository Implementations |         4h | Média      | ✅ Concluído          | [#20](https://github.com/Vandrs/common-cornershop/issues/20) |
+| T5.4 | #21   | Testes — Integration Tests: Controllers com Fastify inject |         4h | Média      | ✅ Concluído (PR #62) | [#21](https://github.com/Vandrs/common-cornershop/issues/21) |
+| T5.5 | #22   |                   Testes — E2E Tests, Fixtures e Factories |         5h | Baixa      | ✅ Concluído (PR #63) | [#22](https://github.com/Vandrs/common-cornershop/issues/22) |
 
 - Critério de conclusão: `yarn test` verde; E2E básicos passando contra docker-compose; cobertura mínima nas services e usecases.
 
@@ -305,11 +305,13 @@ Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (t
 
 - Objetivo: CI/CD mínimo com GitHub Actions.
 
-| ID   | Issue |                                              Título | Estimativa | Prioridade | Status          | Link                                                         |
-| ---- | ----- | --------------------------------------------------: | ---------: | ---------- | --------------- | ------------------------------------------------------------ |
-| T6.2 | #24   | DevOps — GitHub Actions CI/CD (test + build + lint) |         3h | Baixa      | ⬜ Não iniciado | [#24](https://github.com/Vandrs/common-cornershop/issues/24) |
+| ID   | Issue |                                              Título | Estimativa | Prioridade | Status       | Link                                                         |
+| ---- | ----- | --------------------------------------------------: | ---------: | ---------- | ------------ | ------------------------------------------------------------ |
+| T6.2 | #24   | DevOps — GitHub Actions CI/CD (test + build + lint) |         3h | Baixa      | ⏸️ Em espera | [#24](https://github.com/Vandrs/common-cornershop/issues/24) |
 
 - Critério de conclusão: PRs disparam workflow que roda lint, tests e build; PRs bloqueados em caso de falha.
+
+- Nota: T6.2 está atualmente EM ESPERA — motivo: a aplicação não será distribuída por enquanto, portanto o pipeline de distribuição/CI completo ficará pausado até nova decisão de produto/distribuição.
 
 ---
 


### PR DESCRIPTION
## Summary
- update `docs/roadmap.md` last updated date to 2026-04-17
- mark T5.5 as concluded with merged reference (PR #63) and close Phase 4 as concluded
- set T6.2 to **Em espera** with rationale: app distribution is postponed for now

## Why
This keeps roadmap status aligned with current project decisions and avoids signaling CI/CD distribution work as active before distribution is planned.