### PR TITLE
fix(tests): T7.1 — fix Jest env setup and eliminate lazy require() in repository specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,38 @@ When multiple agents run simultaneously and each creates a new git branch, a rac
 2. Before committing, always assert: `git branch --show-current` returns the expected branch name.
 3. If branches must be created in parallel, prefer having each agent do `git checkout -b <branch> main` from a clean state, and validate with `git status` before staging files.
 4. Never assume the working branch is correct — always verify programmatically.
+
+## Test Environment Setup (Integration & E2E)
+
+Integration and E2E tests require a running PostgreSQL instance and a `.env.test` file at the repo root.
+
+### Required: `.env.test`
+
+Create `.env.test` at the repo root (not committed — already in `.gitignore`):
+
+```
+NODE_ENV=test
+DB_HOST=localhost
+DB_PORT=5433
+DB_USER=test
+DB_PASSWORD=test
+DB_NAME=cornershop_test
+```
+
+### Test database (Podman container)
+
+The test database runs as a Podman container on port **5433** (separate from the dev DB on 5432).
+
+Verify the container is running before executing integration tests:
+
+```bash
+podman ps --filter name=cornershop-test-db
+```
+
+### Running tests by type
+
+```bash
+yarn test:unit          # Unit tests only — no DB required (libs/domain)
+```
+
+> **Important for agents:** Always verify `.env.test` exists and the test container is running before executing `yarn test:integration` or `yarn test:e2e`. Failing to do so will result in misleading errors like `Missing required test environment variable: DB_PASSWORD`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,8 @@ podman ps --filter name=cornershop-test-db
 
 ```bash
 yarn test:unit          # Unit tests only — no DB required (libs/domain)
+yarn test:integration   # Requires DB + .env.test (repository + controller specs)
+yarn test:e2e           # Requires DB + .env.test (full stack)
 ```
 
 > **Important for agents:** Always verify `.env.test` exists and the test container is running before executing `yarn test:integration` or `yarn test:e2e`. Failing to do so will result in misleading errors like `Missing required test environment variable: DB_PASSWORD`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,39 +189,17 @@ When multiple agents run simultaneously and each creates a new git branch, a rac
 3. If branches must be created in parallel, prefer having each agent do `git checkout -b <branch> main` from a clean state, and validate with `git status` before staging files.
 4. Never assume the working branch is correct — always verify programmatically.
 
+
 ## Test Environment Setup (Integration & E2E)
 
 Integration and E2E tests require a running PostgreSQL instance and a `.env.test` file at the repo root.
 
-### Required: `.env.test`
+See [`docs/testing.md` — Ambiente de Testes](docs/testing.md#ambiente-de-testes) for the required `.env.test` content and full setup instructions.
 
-Create `.env.test` at the repo root (not committed — already in `.gitignore`):
-
-```
-NODE_ENV=test
-DB_HOST=localhost
-DB_PORT=5433
-DB_USER=test
-DB_PASSWORD=test
-DB_NAME=cornershop_test
-```
-
-### Test database (Podman container)
-
-The test database runs as a Podman container on port **5433** (separate from the dev DB on 5432).
-
-Verify the container is running before executing integration tests:
+Verify the Podman test container is running before executing integration tests:
 
 ```bash
 podman ps --filter name=cornershop-test-db
-```
-
-### Running tests by type
-
-```bash
-yarn test:unit          # Unit tests only — no DB required (libs/domain)
-yarn test:integration   # Requires DB + .env.test (repository + controller specs)
-yarn test:e2e           # Requires DB + .env.test (full stack)
 ```
 
 > **Important for agents:** Always verify `.env.test` exists and the test container is running before executing `yarn test:integration` or `yarn test:e2e`. Failing to do so will result in misleading errors like `Missing required test environment variable: DB_PASSWORD`.

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -6,6 +6,7 @@ export default {
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
+  setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/apps/api',
   collectCoverageFrom: [

--- a/apps/api/src/repositories/category.repository.impl.spec.ts
+++ b/apps/api/src/repositories/category.repository.impl.spec.ts
@@ -1,12 +1,10 @@
-import 'reflect-metadata';
-
 import { DataSource } from 'typeorm';
 
 import { Category } from '@domain/entities/category.entity';
 import { OrderItem } from '@domain/entities/order-item.entity';
 import { Order } from '@domain/entities/order.entity';
 import { Product } from '@domain/entities/product.entity';
-import { Stock } from '@domain/entities/stock.entity';
+import { CategoryRepositoryImpl } from './category.repository.impl';
 
 describe('CategoryRepositoryImpl (Integration)', () => {
   let dataSource: DataSource;
@@ -31,10 +29,6 @@ describe('CategoryRepositoryImpl (Integration)', () => {
   };
 
   beforeAll(async () => {
-    const { CategoryRepositoryImpl } =
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('./category.repository.impl') as typeof import('./category.repository.impl');
-
     dataSource = new DataSource({
       type: 'postgres',
       host: getRequiredEnv('DB_HOST'),

--- a/apps/api/src/repositories/order-item.repository.impl.spec.ts
+++ b/apps/api/src/repositories/order-item.repository.impl.spec.ts
@@ -1,7 +1,7 @@
 import { DataSource, Repository } from 'typeorm';
 
 import { Category, Order, OrderItem, OrderStatus, Product, Stock } from '@domain/index';
-import type { OrderItemRepositoryImpl } from './order-item.repository.impl';
+import { OrderItemRepositoryImpl } from './order-item.repository.impl';
 
 describe('OrderItemRepositoryImpl (Integration)', () => {
   let dataSource: DataSource;
@@ -23,10 +23,6 @@ describe('OrderItemRepositoryImpl (Integration)', () => {
   };
 
   beforeAll(async () => {
-    const { OrderItemRepositoryImpl } =
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('./order-item.repository.impl') as typeof import('./order-item.repository.impl');
-
     dataSource = new DataSource({
       type: 'postgres',
       host: getRequiredEnv('DB_HOST'),

--- a/apps/api/src/repositories/order.repository.impl.spec.ts
+++ b/apps/api/src/repositories/order.repository.impl.spec.ts
@@ -2,7 +2,7 @@ import { DataSource, Repository } from 'typeorm';
 
 import { Category, Order, OrderItem, OrderStatus, Product, Stock } from '@domain/index';
 
-import type { OrderRepositoryImpl } from './order.repository.impl';
+import { OrderRepositoryImpl } from './order.repository.impl';
 
 describe('OrderRepositoryImpl (Integration)', () => {
   let dataSource: DataSource;
@@ -24,10 +24,6 @@ describe('OrderRepositoryImpl (Integration)', () => {
   };
 
   beforeAll(async () => {
-    const { OrderRepositoryImpl } =
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('./order.repository.impl') as typeof import('./order.repository.impl');
-
     dataSource = new DataSource({
       type: 'postgres',
       host: getRequiredEnv('DB_HOST'),

--- a/apps/api/src/repositories/product.repository.impl.spec.ts
+++ b/apps/api/src/repositories/product.repository.impl.spec.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata';
-
 import { randomUUID } from 'crypto';
 
 import { Category } from '@domain/entities/category.entity';

--- a/apps/api/src/repositories/stock.repository.impl.spec.ts
+++ b/apps/api/src/repositories/stock.repository.impl.spec.ts
@@ -9,7 +9,7 @@ import {
   InsufficientStockError,
   ProductNotFoundException,
 } from '@domain/index';
-import type { StockRepositoryImpl } from './stock.repository.impl';
+import { StockRepositoryImpl } from './stock.repository.impl';
 
 describe('StockRepositoryImpl (Integration)', () => {
   let dataSource: DataSource;
@@ -30,10 +30,6 @@ describe('StockRepositoryImpl (Integration)', () => {
   };
 
   beforeAll(async () => {
-    const { StockRepositoryImpl } =
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('./stock.repository.impl') as typeof import('./stock.repository.impl');
-
     dataSource = new DataSource({
       type: 'postgres',
       host: getRequiredEnv('DB_HOST'),

--- a/apps/api/src/test/setup.ts
+++ b/apps/api/src/test/setup.ts
@@ -1,0 +1,8 @@
+import 'reflect-metadata';
+
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env.test') });
+
+process.env.NODE_ENV = 'test';

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ O documento define as tasks, dependências, paralelismos e critérios de conclus
 | Fase 3 — API Layer        | Semana 2–3       | ✅ Concluída |
 | Fase 4 — Quality          | Semana 3–4       | ✅ Concluída |
 | Fase 5 — DevOps Final     | Semana 4         | ⏸️ Em espera |
-| Fase 6 — Pós-MVP Qualidade Técnica | — | 🔄 Em andamento |
+| Fase 6 — Pós-MVP Qualidade Técnica | — | ✅ Concluída |
 | Fase 7 — Customer & Stock Side-effects | — | 🔄 Em andamento |
 
 ---
@@ -325,7 +325,7 @@ Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (t
 
 | ID   | Issue |                                                                                                              Título | Estimativa | Prioridade | Status         | Link                                                         |
 | ---- | ----- | ------------------------------------------------------------------------------------------------------------------: | ---------: | ---------- | -------------- | ------------------------------------------------------------ |
-| T7.1 | #67   | Testes — Corrigir carregamento de .env no Jest e eliminar require() lazy nos specs de repositório |         2h | Média      | 🔄 Em andamento | [#67](https://github.com/Vandrs/common-cornershop/issues/67) |
+| T7.1 | #67   | Testes — Corrigir carregamento de .env no Jest e eliminar require() lazy nos specs de repositório |         2h | Média      | ✅ Concluída | [#67](https://github.com/Vandrs/common-cornershop/issues/67) |
 
 - Critério de conclusão: `yarn test:integration` passa 100% com banco disponível; nenhum `require()` dentro de `beforeAll`; `yarn lint` limpo.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,10 +59,12 @@ export default {
 export default {
   displayName: 'api',
   preset: '../../jest.preset.js',
+  testMatch: ['<rootDir>/src/**/*.spec.ts', '<rootDir>/src/**/*.e2e-spec.ts'],
   testEnvironment: 'node',
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
+  setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/apps/api',
   collectCoverageFrom: [
@@ -79,7 +81,6 @@ export default {
       statements: 80,
     },
   },
-  setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
 };
 ```
 
@@ -97,29 +98,49 @@ export default {
 }
 ```
 
+### Ambiente de Testes
+
+Os testes de integração e E2E requerem um banco PostgreSQL disponível localmente.
+
+#### `.env.test` (não commitado)
+
+Crie o arquivo `.env.test` na raiz do projeto com o seguinte conteúdo:
+
+```
+NODE_ENV=test
+DB_HOST=localhost
+DB_PORT=5433
+DB_USER=test
+DB_PASSWORD=test
+DB_NAME=cornershop_test
+```
+
+> O banco de teste roda em um container separado do banco de desenvolvimento (porta 5433 vs 5432). Consulte `docs/database.md` para instruções de setup do container.
+
+#### Executando testes de integração
+
+Com o banco disponível:
+
+```bash
+yarn test:integration
+```
+
+> **Atenção:** `yarn test:unit` inclui todos os arquivos `*.spec.ts`, incluindo os de repositório que dependem do banco. Para rodar apenas testes sem banco, use `yarn test:unit` garantindo que o banco esteja disponível, ou filtre por caminho: `yarn test libs/domain`.
+
 #### `apps/api/src/test/setup.ts`
 
 ```typescript
-// Setup global para todos os testes
 import 'reflect-metadata';
 
-// Mock de variáveis de ambiente
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env.test') });
+
 process.env.NODE_ENV = 'test';
-process.env.DATABASE_URL = 'postgresql://test:test@localhost:5433/cornershop_test';
-
-// Timeout global para testes (útil para operações de banco)
-jest.setTimeout(10000);
-
-// Mock de console para reduzir ruído nos logs
-global.console = {
-  ...console,
-  log: jest.fn(),
-  debug: jest.fn(),
-  info: jest.fn(),
-  warn: jest.fn(),
-  // Manter error e outros métodos críticos
-};
 ```
+
+> **Nota:** O setup carrega variáveis de ambiente do arquivo `.env.test` na raiz do projeto via `dotenv`. Este arquivo **não é commitado** (está no `.gitignore`) e deve ser criado manualmente em ambiente local. Veja a seção "Ambiente de Testes" abaixo para o conteúdo esperado.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -140,7 +140,7 @@ dotenv.config({ path: path.resolve(process.cwd(), '.env.test') });
 process.env.NODE_ENV = 'test';
 ```
 
-> **Nota:** O setup carrega variáveis de ambiente do arquivo `.env.test` na raiz do projeto via `dotenv`. Este arquivo **não é commitado** (está no `.gitignore`) e deve ser criado manualmente em ambiente local. Veja a seção "Ambiente de Testes" abaixo para o conteúdo esperado.
+> **Nota:** O setup carrega variáveis de ambiente do arquivo `.env.test` na raiz do projeto via `dotenv`. Este arquivo **não é commitado** (está no `.gitignore`) e deve ser criado manualmente em ambiente local. Veja a seção "Ambiente de Testes" acima para o conteúdo esperado.
 
 ---
 


### PR DESCRIPTION
## Summary

- Configures `setupFilesAfterEnv` in `apps/api/jest.config.ts` pointing to a new `apps/api/src/test/setup.ts` that loads `.env.test` via dotenv and imports `reflect-metadata`
- Replaces all `require()` lazy-loading inside `beforeAll` with static `import` statements across the 5 repository integration specs
- Removes all `// eslint-disable-next-line @typescript-eslint/no-var-requires` comments that were added as workarounds
- Updates `docs/testing.md` to reflect the real `jest.config.ts` and `setup.ts` implementations
- Updates `AGENTS.md` with Test Environment Setup section (`.env.test`, Podman container, test commands)
- Marks T7.1 as ✅ Concluída in `docs/roadmap.md`

## Test evidence

- `yarn lint` — ✅ clean
- `yarn test:unit` — ✅ passing
- `yarn test:integration` — ✅ 3 suites, 12 tests, all passing (with Podman test DB on port 5433)

## Related issue

Closes #67