### PR TITLE
feat(domain): add Customer aggregate and require customerId on order creation

### DIFF
--- a/apps/api/src/container/dependency-injection.ts
+++ b/apps/api/src/container/dependency-injection.ts
@@ -1,35 +1,30 @@
 import 'reflect-metadata';
 import { container } from 'tsyringe';
 
-// Repository implementations (stubs — will be replaced by TypeORM impls in T4.3)
 import { CategoryRepositoryImpl } from '../repositories/category.repository.impl';
 import { ProductRepositoryImpl } from '../repositories/product.repository.impl';
 import { StockRepositoryImpl } from '../repositories/stock.repository.impl';
 import { OrderRepositoryImpl } from '../repositories/order.repository.impl';
 import { OrderItemRepositoryImpl } from '../repositories/order-item.repository.impl';
+import { CustomerRepositoryImpl } from '../repositories/customer.repository.impl';
 
-// Domain services
 import {
   CategoryService,
   ProductService,
   StockService,
   OrderService,
-  // Category use cases
   CreateCategoryUseCase,
   ListCategoriesUseCase,
   GetCategoryUseCase,
   UpdateCategoryUseCase,
   DeleteCategoryUseCase,
-  // Product use cases
   CreateProductUseCase,
   ListProductsUseCase,
   GetProductUseCase,
   UpdateProductUseCase,
   DeleteProductUseCase,
-  // Stock use cases
   GetStockUseCase,
   UpdateStockUseCase,
-  // Order use cases
   CreateOrderUseCase,
   GetOrderUseCase,
   ListOrdersUseCase,
@@ -54,7 +49,6 @@ import {
  * file.
  */
 export function registerDependencies(): void {
-  // ── Repositories ──────────────────────────────────────────────────────────
   container.registerSingleton<CategoryRepositoryImpl>(
     'ICategoryRepository',
     CategoryRepositoryImpl,
@@ -66,14 +60,16 @@ export function registerDependencies(): void {
     'IOrderItemRepository',
     OrderItemRepositoryImpl,
   );
+  container.registerSingleton<CustomerRepositoryImpl>(
+    'ICustomerRepository',
+    CustomerRepositoryImpl,
+  );
 
-  // ── Services ──────────────────────────────────────────────────────────────
   container.registerSingleton<CategoryService>('CategoryService', CategoryService);
   container.registerSingleton<ProductService>('ProductService', ProductService);
   container.registerSingleton<StockService>('StockService', StockService);
   container.registerSingleton<OrderService>('OrderService', OrderService);
 
-  // ── Use Cases — Category ──────────────────────────────────────────────────
   container.registerSingleton<CreateCategoryUseCase>(
     'CreateCategoryUseCase',
     CreateCategoryUseCase,
@@ -92,18 +88,15 @@ export function registerDependencies(): void {
     DeleteCategoryUseCase,
   );
 
-  // ── Use Cases — Product ───────────────────────────────────────────────────
   container.registerSingleton<CreateProductUseCase>('CreateProductUseCase', CreateProductUseCase);
   container.registerSingleton<ListProductsUseCase>('ListProductsUseCase', ListProductsUseCase);
   container.registerSingleton<GetProductUseCase>('GetProductUseCase', GetProductUseCase);
   container.registerSingleton<UpdateProductUseCase>('UpdateProductUseCase', UpdateProductUseCase);
   container.registerSingleton<DeleteProductUseCase>('DeleteProductUseCase', DeleteProductUseCase);
 
-  // ── Use Cases — Stock ─────────────────────────────────────────────────────
   container.registerSingleton<GetStockUseCase>('GetStockUseCase', GetStockUseCase);
   container.registerSingleton<UpdateStockUseCase>('UpdateStockUseCase', UpdateStockUseCase);
 
-  // ── Use Cases — Order ─────────────────────────────────────────────────────
   container.registerSingleton<CreateOrderUseCase>('CreateOrderUseCase', CreateOrderUseCase);
   container.registerSingleton<GetOrderUseCase>('GetOrderUseCase', GetOrderUseCase);
   container.registerSingleton<ListOrdersUseCase>('ListOrdersUseCase', ListOrdersUseCase);

--- a/apps/api/src/database/data-source.ts
+++ b/apps/api/src/database/data-source.ts
@@ -5,6 +5,7 @@ import { Product } from '@domain/entities/product.entity';
 import { Stock } from '@domain/entities/stock.entity';
 import { Order } from '@domain/entities/order.entity';
 import { OrderItem } from '@domain/entities/order-item.entity';
+import { Customer } from '@domain/entities/customer.entity';
 
 import { getDatabaseConfig } from '../config/database.config';
 
@@ -15,7 +16,7 @@ import { getDatabaseConfig } from '../config/database.config';
  * project runs inside an NX monorepo where glob paths are not reliably
  * resolved by the TypeORM CLI or the compiled output.
  */
-const ENTITIES = [Category, Product, Stock, Order, OrderItem];
+const ENTITIES = [Category, Product, Stock, Order, OrderItem, Customer];
 
 const dbConfig = getDatabaseConfig();
 

--- a/apps/api/src/database/migrations/1743200050000-CreateCustomerTable.ts
+++ b/apps/api/src/database/migrations/1743200050000-CreateCustomerTable.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * Creates the `customers` table with unique constraints for email and phone.
+ */
+export class CreateCustomerTable1743200050000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'customers',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '100',
+            isNullable: false,
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'phone',
+            type: 'varchar',
+            length: '20',
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            isNullable: false,
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            isNullable: false,
+            default: 'now()',
+          },
+          {
+            name: 'deleted_at',
+            type: 'timestamp',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_CUSTOMER_EMAIL_LOWER" ON "customers" (LOWER(email))`,
+    );
+
+    await queryRunner.createIndex(
+      'customers',
+      new TableIndex({
+        name: 'IDX_CUSTOMER_PHONE',
+        columnNames: ['phone'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('customers', 'IDX_CUSTOMER_PHONE');
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_CUSTOMER_EMAIL_LOWER"`);
+    await queryRunner.dropTable('customers');
+  }
+}

--- a/apps/api/src/database/migrations/1743200060000-AddCustomerIdToOrders.ts
+++ b/apps/api/src/database/migrations/1743200060000-AddCustomerIdToOrders.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Adds required customer reference to the `orders` table.
+ */
+export class AddCustomerIdToOrders1743200060000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const legacyCustomerId = '00000000-0000-0000-0000-000000000001';
+
+    await queryRunner.query(
+      `
+        INSERT INTO "customers" ("id", "name", "email", "phone", "created_at", "updated_at")
+        VALUES ($1, 'Cliente legado', 'legacy.customer@cornershop.local', '0000000000000', now(), now())
+        ON CONFLICT ("id") DO NOTHING
+      `,
+      [legacyCustomerId],
+    );
+
+    await queryRunner.addColumn(
+      'orders',
+      new TableColumn({
+        name: 'customer_id',
+        type: 'uuid',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.query(`UPDATE "orders" SET "customer_id" = $1 WHERE "customer_id" IS NULL`, [
+      legacyCustomerId,
+    ]);
+
+    await queryRunner.query(`ALTER TABLE "orders" ALTER COLUMN "customer_id" SET NOT NULL`);
+
+    await queryRunner.createForeignKey(
+      'orders',
+      new TableForeignKey({
+        name: 'FK_ORDER_CUSTOMER',
+        columnNames: ['customer_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'customers',
+        onDelete: 'RESTRICT',
+        onUpdate: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'orders',
+      new TableIndex({
+        name: 'IDX_ORDER_CUSTOMER',
+        columnNames: ['customer_id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('orders', 'IDX_ORDER_CUSTOMER');
+    await queryRunner.query(`ALTER TABLE "orders" DROP CONSTRAINT "FK_ORDER_CUSTOMER"`);
+    await queryRunner.dropColumn('orders', 'customer_id');
+
+    await queryRunner.query(
+      `DELETE FROM "customers" WHERE "id" = '00000000-0000-0000-0000-000000000001'`,
+    );
+  }
+}

--- a/apps/api/src/http/controllers/order.controller.integration.spec.ts
+++ b/apps/api/src/http/controllers/order.controller.integration.spec.ts
@@ -47,7 +47,6 @@ describe('OrderController (integration)', () => {
   });
 
   it('should create order on POST /api/orders', async () => {
-    // Arrange
     createOrderUseCase.execute.mockResolvedValue({
       id: '623e4567-e89b-12d3-a456-426614174005',
       orderNumber: 'ORD-1710501234567-A3F9',
@@ -71,18 +70,18 @@ describe('OrderController (integration)', () => {
       updatedAt: new Date('2026-03-15T15:00:00.000Z'),
     });
 
-    // Act
     const response = await app.inject({
       method: 'POST',
       url: '/api/orders',
       payload: {
+        customerId: '223e4567-e89b-12d3-a456-426614174001',
         items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
       },
     });
 
-    // Assert
     expect(response.statusCode).toBe(201);
     expect(createOrderUseCase.execute).toHaveBeenCalledWith({
+      customerId: '223e4567-e89b-12d3-a456-426614174001',
       items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
     });
     expect(response.json()).toEqual({
@@ -110,14 +109,12 @@ describe('OrderController (integration)', () => {
   });
 
   it('should return ValidationError envelope for invalid create payload', async () => {
-    // Act
     const response = await app.inject({
       method: 'POST',
       url: '/api/orders',
       payload: {},
     });
 
-    // Assert
     expect(response.statusCode).toBe(400);
     expect(response.json()).toEqual(
       expect.objectContaining({
@@ -133,19 +130,17 @@ describe('OrderController (integration)', () => {
   });
 
   it('should return InsufficientStockError envelope when stock is insufficient', async () => {
-    // Arrange
     createOrderUseCase.execute.mockRejectedValue(new InsufficientStockError('Coca-Cola 2L'));
 
-    // Act
     const response = await app.inject({
       method: 'POST',
       url: '/api/orders',
       payload: {
+        customerId: '223e4567-e89b-12d3-a456-426614174001',
         items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
       },
     });
 
-    // Assert
     expect(response.statusCode).toBe(400);
     expect(response.json()).toEqual({
       error: 'InsufficientStockError',
@@ -154,7 +149,6 @@ describe('OrderController (integration)', () => {
   });
 
   it('should return order list on GET /api/orders and parse filters', async () => {
-    // Arrange
     listOrdersUseCase.execute.mockResolvedValue({
       data: [
         {
@@ -171,13 +165,11 @@ describe('OrderController (integration)', () => {
       meta: { page: 1, limit: 10, total: 1, totalPages: 1 },
     });
 
-    // Act
     const response = await app.inject({
       method: 'GET',
       url: '/api/orders?page=1&limit=10&status=PENDING&dateFrom=2026-03-01T00:00:00.000Z&dateTo=2026-03-31T23:59:59.000Z',
     });
 
-    // Assert
     expect(response.statusCode).toBe(200);
     expect(listOrdersUseCase.execute).toHaveBeenCalledWith({
       page: 1,
@@ -203,13 +195,11 @@ describe('OrderController (integration)', () => {
   });
 
   it('should return ValidationError envelope for invalid list filters', async () => {
-    // Act
     const response = await app.inject({
       method: 'GET',
       url: '/api/orders?status=INVALID',
     });
 
-    // Assert
     expect(response.statusCode).toBe(400);
     expect(response.json()).toEqual(
       expect.objectContaining({
@@ -225,16 +215,13 @@ describe('OrderController (integration)', () => {
   });
 
   it('should return OrderNotFoundException envelope on GET /api/orders/:id', async () => {
-    // Arrange
     getOrderUseCase.execute.mockRejectedValue(new OrderNotFoundException());
 
-    // Act
     const response = await app.inject({
       method: 'GET',
       url: '/api/orders/623e4567-e89b-12d3-a456-426614174005',
     });
 
-    // Assert
     expect(response.statusCode).toBe(404);
     expect(response.json()).toEqual({
       error: 'OrderNotFoundException',

--- a/apps/api/src/http/controllers/order.controller.spec.ts
+++ b/apps/api/src/http/controllers/order.controller.spec.ts
@@ -13,6 +13,7 @@ import { OrderController } from './order.controller';
 const makeOrder = (): Order => {
   const order = new Order();
   order.id = '123e4567-e89b-12d3-a456-426614174000';
+  order.customerId = '223e4567-e89b-12d3-a456-426614174001';
   order.orderNumber = 'ORD-1710501234567-A3F9';
   order.status = OrderStatus.PENDING;
   order.totalAmount = 24.5;
@@ -68,6 +69,7 @@ describe('OrderController', () => {
 
     const request = {
       body: {
+        customerId: '223e4567-e89b-12d3-a456-426614174001',
         items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
       },
     } as unknown;
@@ -79,6 +81,7 @@ describe('OrderController', () => {
     await controller.create(request as never, reply);
 
     expect(createOrderUseCase.execute).toHaveBeenCalledWith({
+      customerId: '223e4567-e89b-12d3-a456-426614174001',
       items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
     });
     expect(status).toHaveBeenCalledWith(201);

--- a/apps/api/src/http/controllers/order.controller.ts
+++ b/apps/api/src/http/controllers/order.controller.ts
@@ -90,6 +90,7 @@ export class OrderController {
     const body = createOrderBodySchema.parse(request.body) as CreateOrderBodySchema;
 
     const order = await this.createOrderUseCase.execute({
+      customerId: body.customerId,
       items: body.items,
     });
 

--- a/apps/api/src/http/schemas/__tests__/schemas.spec.ts
+++ b/apps/api/src/http/schemas/__tests__/schemas.spec.ts
@@ -47,6 +47,7 @@ describe('http zod schemas', () => {
   describe('createOrderBodySchema', () => {
     it('parses valid create order payload', () => {
       const parsed = createOrderBodySchema.parse({
+        customerId: '223e4567-e89b-12d3-a456-426614174001',
         items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
       });
 
@@ -55,7 +56,20 @@ describe('http zod schemas', () => {
     });
 
     it('rejects empty items list', () => {
-      expect(() => createOrderBodySchema.parse({ items: [] })).toThrow();
+      expect(() =>
+        createOrderBodySchema.parse({
+          customerId: '223e4567-e89b-12d3-a456-426614174001',
+          items: [],
+        }),
+      ).toThrow();
+    });
+
+    it('rejects missing customerId', () => {
+      expect(() =>
+        createOrderBodySchema.parse({
+          items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
+        }),
+      ).toThrow();
     });
   });
 

--- a/apps/api/src/http/schemas/orders.schema.ts
+++ b/apps/api/src/http/schemas/orders.schema.ts
@@ -21,6 +21,7 @@ const orderProductCreatedSummarySchema = orderProductSummarySchema.extend({
 });
 
 export const createOrderBodySchema = z.object({
+  customerId: uuidSchema,
   items: z
     .array(
       z.object({

--- a/apps/api/src/plugins/error-handler.plugin.spec.ts
+++ b/apps/api/src/plugins/error-handler.plugin.spec.ts
@@ -7,6 +7,7 @@ import {
   InsufficientStockError,
   OrderNotFoundException,
   InvalidOrderStatusTransitionError,
+  CustomerNotFoundException,
 } from '@domain/index';
 import { OrderStatus } from '@domain/enums/order-status.enum';
 
@@ -34,13 +35,10 @@ async function buildApp(throwFn: () => Error): Promise<FastifyInstance> {
 describe('registerErrorHandler', () => {
   describe('when a mapped DomainError is thrown', () => {
     it('maps ProductNotFoundException to 404 with correct envelope', async () => {
-      // Arrange
       const app = await buildApp(() => new ProductNotFoundException());
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(404);
       const body = JSON.parse(response.body);
       expect(body).toEqual({
@@ -52,13 +50,10 @@ describe('registerErrorHandler', () => {
     });
 
     it('maps CategoryNotFoundException to 404 with correct envelope', async () => {
-      // Arrange
       const app = await buildApp(() => new CategoryNotFoundException());
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(404);
       const body = JSON.parse(response.body);
       expect(body).toEqual({
@@ -68,13 +63,10 @@ describe('registerErrorHandler', () => {
     });
 
     it('maps InsufficientStockError to 400 with correct envelope', async () => {
-      // Arrange
       const app = await buildApp(() => new InsufficientStockError('Coca-Cola 2L'));
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(400);
       const body = JSON.parse(response.body);
       expect(body).toEqual({
@@ -84,13 +76,10 @@ describe('registerErrorHandler', () => {
     });
 
     it('maps OrderNotFoundException to 404 with correct envelope', async () => {
-      // Arrange
       const app = await buildApp(() => new OrderNotFoundException());
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(404);
       const body = JSON.parse(response.body);
       expect(body).toEqual({
@@ -99,16 +88,26 @@ describe('registerErrorHandler', () => {
       });
     });
 
+    it('maps CustomerNotFoundException to 404 with correct envelope', async () => {
+      const app = await buildApp(() => new CustomerNotFoundException());
+
+      const response = await app.inject({ method: 'GET', url: '/test' });
+
+      expect(response.statusCode).toBe(404);
+      const body = JSON.parse(response.body);
+      expect(body).toEqual({
+        error: 'CustomerNotFoundException',
+        message: 'Cliente não encontrado',
+      });
+    });
+
     it('maps InvalidOrderStatusTransitionError to 400 with correct envelope', async () => {
-      // Arrange
       const app = await buildApp(
         () => new InvalidOrderStatusTransitionError(OrderStatus.COMPLETED, OrderStatus.PENDING),
       );
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(400);
       const body = JSON.parse(response.body);
       expect(body).toEqual({
@@ -118,13 +117,10 @@ describe('registerErrorHandler', () => {
     });
 
     it('does not expose stack trace for domain errors', async () => {
-      // Arrange
       const app = await buildApp(() => new ProductNotFoundException());
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       const body = JSON.parse(response.body);
       expect(body).not.toHaveProperty('stack');
       expect(JSON.stringify(body)).not.toContain('at ');
@@ -133,7 +129,6 @@ describe('registerErrorHandler', () => {
 
   describe('when a ZodError is thrown', () => {
     it('returns 400 with ValidationError envelope and details array', async () => {
-      // Arrange
       const schema = z.object({
         items: z.array(z.object({ quantity: z.number().int().positive() })).min(1),
       });
@@ -144,10 +139,8 @@ describe('registerErrorHandler', () => {
         return new Error('should not reach here');
       });
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(400);
       const body = JSON.parse(response.body);
       expect(body.error).toBe('ValidationError');
@@ -159,7 +152,6 @@ describe('registerErrorHandler', () => {
     });
 
     it('includes path-based field names in details', async () => {
-      // Arrange
       const schema = z.object({ name: z.string().min(1) });
       const app = await buildApp(() => {
         const result = schema.safeParse({ name: '' });
@@ -167,17 +159,14 @@ describe('registerErrorHandler', () => {
         return new Error('should not reach here');
       });
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       const body = JSON.parse(response.body);
       const nameDetail = body.details.find((d: { field: string }) => d.field === 'name');
       expect(nameDetail).toBeDefined();
     });
 
     it('does not expose stack trace for ZodErrors', async () => {
-      // Arrange
       const schema = z.object({ id: z.string().uuid() });
       const app = await buildApp(() => {
         const result = schema.safeParse({ id: 'not-a-uuid' });
@@ -185,10 +174,8 @@ describe('registerErrorHandler', () => {
         return new Error('should not reach here');
       });
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       const body = JSON.parse(response.body);
       expect(body).not.toHaveProperty('stack');
     });
@@ -196,13 +183,10 @@ describe('registerErrorHandler', () => {
 
   describe('when an unexpected / generic error is thrown', () => {
     it('returns 500 with InternalServerError envelope', async () => {
-      // Arrange
       const app = await buildApp(() => new Error('Something went wrong internally'));
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(500);
       const body = JSON.parse(response.body);
       expect(body).toEqual({
@@ -212,14 +196,11 @@ describe('registerErrorHandler', () => {
     });
 
     it('does not expose the internal error message or stack trace', async () => {
-      // Arrange
       const sensitiveMessage = 'DB connection string: postgresql://user:secret@host/db';
       const app = await buildApp(() => new Error(sensitiveMessage));
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       expect(response.statusCode).toBe(500);
       const rawBody = response.body;
       expect(rawBody).not.toContain(sensitiveMessage);
@@ -228,13 +209,10 @@ describe('registerErrorHandler', () => {
     });
 
     it('does not include statusCode in the response body', async () => {
-      // Arrange
       const app = await buildApp(() => new Error('generic'));
 
-      // Act
       const response = await app.inject({ method: 'GET', url: '/test' });
 
-      // Assert
       const body = JSON.parse(response.body);
       expect(body).not.toHaveProperty('statusCode');
     });

--- a/apps/api/src/plugins/error-handler.plugin.ts
+++ b/apps/api/src/plugins/error-handler.plugin.ts
@@ -8,6 +8,7 @@ import {
   InsufficientStockError,
   OrderNotFoundException,
   InvalidOrderStatusTransitionError,
+  CustomerNotFoundException,
 } from '@domain/index';
 
 /**
@@ -63,6 +64,10 @@ const errorMap = new Map<new (...args: never[]) => DomainError, ErrorMapEntry>([
       message: 'Transição de status inválida para o pedido',
     },
   ],
+  [
+    CustomerNotFoundException,
+    { status: 404, error: 'CustomerNotFoundException', message: 'Cliente não encontrado' },
+  ],
 ]);
 
 /**
@@ -82,7 +87,6 @@ const errorMap = new Map<new (...args: never[]) => DomainError, ErrorMapEntry>([
  */
 export function registerErrorHandler(app: FastifyInstance): void {
   app.setErrorHandler((error: Error, request: FastifyRequest, reply: FastifyReply): void => {
-    // ── Path 1: Known domain errors ──────────────────────────────────────
     if (error instanceof DomainError) {
       const entry = errorMap.get(error.constructor as new (...args: never[]) => DomainError);
 
@@ -94,7 +98,6 @@ export function registerErrorHandler(app: FastifyInstance): void {
         return;
       }
 
-      // Unmapped DomainError subclass — treat as internal (defensive).
       request.log.error({ err: error }, 'Unmapped DomainError encountered');
       reply.status(500).send({
         error: 'InternalServerError',
@@ -103,7 +106,6 @@ export function registerErrorHandler(app: FastifyInstance): void {
       return;
     }
 
-    // ── Path 2: Zod validation errors ────────────────────────────────────
     if (error instanceof ZodError) {
       const details: ValidationDetail[] = error.issues.map((issue) => ({
         field: issue.path.join('.') || 'unknown',
@@ -118,8 +120,6 @@ export function registerErrorHandler(app: FastifyInstance): void {
       return;
     }
 
-    // ── Path 3: Unexpected / infrastructure errors ────────────────────────
-    // Log with full stack trace internally — never expose to the client.
     request.log.error({ err: error }, 'Unexpected internal error');
     reply.status(500).send({
       error: 'InternalServerError',

--- a/apps/api/src/repositories/customer.repository.impl.ts
+++ b/apps/api/src/repositories/customer.repository.impl.ts
@@ -1,0 +1,44 @@
+import { injectable } from 'tsyringe';
+import { DataSource, IsNull, Repository } from 'typeorm';
+
+import { Customer } from '@domain/entities/customer.entity';
+import { ICustomerRepository } from '@domain/repositories/customer.repository';
+
+import { AppDataSource } from '../database/data-source';
+
+/**
+ * TypeORM implementation of ICustomerRepository.
+ */
+@injectable()
+export class CustomerRepositoryImpl implements ICustomerRepository {
+  constructor(private readonly dataSource: DataSource = AppDataSource) {}
+
+  private get repository(): Repository<Customer> {
+    return this.dataSource.getRepository(Customer);
+  }
+
+  async findById(id: string): Promise<Customer | null> {
+    return this.repository.findOne({
+      where: {
+        id,
+        deletedAt: IsNull(),
+      },
+    });
+  }
+
+  async findByEmail(email: string): Promise<Customer | null> {
+    return this.repository
+      .createQueryBuilder('customer')
+      .where('LOWER(customer.email) = LOWER(:email)', { email })
+      .andWhere('customer.deletedAt IS NULL')
+      .getOne();
+  }
+
+  async save(customer: Customer): Promise<Customer> {
+    return this.repository.save(customer);
+  }
+
+  async softDelete(id: string): Promise<void> {
+    await this.repository.softDelete(id);
+  }
+}

--- a/apps/api/src/repositories/order-item.repository.impl.spec.ts
+++ b/apps/api/src/repositories/order-item.repository.impl.spec.ts
@@ -1,11 +1,12 @@
 import { DataSource, Repository } from 'typeorm';
 
-import { Category, Order, OrderItem, OrderStatus, Product, Stock } from '@domain/index';
+import { Category, Customer, Order, OrderItem, OrderStatus, Product, Stock } from '@domain/index';
 import { OrderItemRepositoryImpl } from './order-item.repository.impl';
 
 describe('OrderItemRepositoryImpl (Integration)', () => {
   let dataSource: DataSource;
   let categoryRepo: Repository<Category>;
+  let customerRepo: Repository<Customer>;
   let productRepo: Repository<Product>;
   let orderRepo: Repository<Order>;
   let orderItemOrmRepo: Repository<OrderItem>;
@@ -30,7 +31,7 @@ describe('OrderItemRepositoryImpl (Integration)', () => {
       username: getRequiredEnv('DB_USER'),
       password: getRequiredEnv('DB_PASSWORD'),
       database: getRequiredEnv('DB_NAME'),
-      entities: [Category, Product, Stock, Order, OrderItem],
+      entities: [Category, Product, Stock, Order, OrderItem, Customer],
       synchronize: true,
       dropSchema: true,
       logging: false,
@@ -40,6 +41,7 @@ describe('OrderItemRepositoryImpl (Integration)', () => {
     await dataSource.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
 
     categoryRepo = dataSource.getRepository(Category);
+    customerRepo = dataSource.getRepository(Customer);
     productRepo = dataSource.getRepository(Product);
     orderRepo = dataSource.getRepository(Order);
     orderItemOrmRepo = dataSource.getRepository(OrderItem);
@@ -55,9 +57,19 @@ describe('OrderItemRepositoryImpl (Integration)', () => {
 
   beforeEach(async () => {
     await dataSource.query(
-      'TRUNCATE TABLE order_items, orders, stocks, products, categories RESTART IDENTITY CASCADE',
+      'TRUNCATE TABLE order_items, orders, customers, stocks, products, categories RESTART IDENTITY CASCADE',
     );
   });
+
+  const createCustomer = async (): Promise<Customer> => {
+    return customerRepo.save(
+      customerRepo.create({
+        name: `Customer-${Date.now()}-${Math.random()}`,
+        email: `customer-${Date.now()}-${Math.floor(Math.random() * 10000)}@test.com`,
+        phone: `${Date.now()}${Math.floor(Math.random() * 1000)}`,
+      }),
+    );
+  };
 
   const createCategory = async (): Promise<Category> => {
     return categoryRepo.save(
@@ -82,8 +94,11 @@ describe('OrderItemRepositoryImpl (Integration)', () => {
   };
 
   const createOrder = async (): Promise<Order> => {
+    const customer = await createCustomer();
+
     return orderRepo.save(
       orderRepo.create({
+        customerId: customer.id,
         orderNumber: `ORD-${Date.now()}-${Math.floor(Math.random() * 10000)}`,
         status: OrderStatus.PENDING,
         totalAmount: 0,

--- a/apps/api/src/repositories/order.repository.impl.spec.ts
+++ b/apps/api/src/repositories/order.repository.impl.spec.ts
@@ -1,6 +1,6 @@
 import { DataSource, Repository } from 'typeorm';
 
-import { Category, Order, OrderItem, OrderStatus, Product, Stock } from '@domain/index';
+import { Category, Customer, Order, OrderItem, OrderStatus, Product, Stock } from '@domain/index';
 
 import { OrderRepositoryImpl } from './order.repository.impl';
 
@@ -8,6 +8,7 @@ describe('OrderRepositoryImpl (Integration)', () => {
   let dataSource: DataSource;
   let categoryRepo: Repository<Category>;
   let productRepo: Repository<Product>;
+  let customerRepo: Repository<Customer>;
   let orderOrmRepo: Repository<Order>;
   let orderItemOrmRepo: Repository<OrderItem>;
 
@@ -31,7 +32,7 @@ describe('OrderRepositoryImpl (Integration)', () => {
       username: getRequiredEnv('DB_USER'),
       password: getRequiredEnv('DB_PASSWORD'),
       database: getRequiredEnv('DB_NAME'),
-      entities: [Category, Product, Stock, Order, OrderItem],
+      entities: [Category, Product, Stock, Order, OrderItem, Customer],
       synchronize: true,
       dropSchema: true,
       logging: false,
@@ -42,6 +43,7 @@ describe('OrderRepositoryImpl (Integration)', () => {
 
     categoryRepo = dataSource.getRepository(Category);
     productRepo = dataSource.getRepository(Product);
+    customerRepo = dataSource.getRepository(Customer);
     orderOrmRepo = dataSource.getRepository(Order);
     orderItemOrmRepo = dataSource.getRepository(OrderItem);
 
@@ -56,9 +58,19 @@ describe('OrderRepositoryImpl (Integration)', () => {
 
   beforeEach(async () => {
     await dataSource.query(
-      'TRUNCATE TABLE order_items, orders, stocks, products, categories RESTART IDENTITY CASCADE',
+      'TRUNCATE TABLE order_items, orders, customers, stocks, products, categories RESTART IDENTITY CASCADE',
     );
   });
+
+  const createCustomer = async (): Promise<Customer> => {
+    return customerRepo.save(
+      customerRepo.create({
+        name: `Customer-${Date.now()}-${Math.random()}`,
+        email: `customer-${Date.now()}-${Math.floor(Math.random() * 10000)}@test.com`,
+        phone: `${Date.now()}${Math.floor(Math.random() * 1000)}`,
+      }),
+    );
+  };
 
   const createCategory = async (): Promise<Category> => {
     return categoryRepo.save(
@@ -82,8 +94,14 @@ describe('OrderRepositoryImpl (Integration)', () => {
     );
   };
 
-  const createOrderEntity = (orderNumber: string, status: OrderStatus, totalAmount = 0): Order => {
+  const createOrderEntity = (
+    customerId: string,
+    orderNumber: string,
+    status: OrderStatus,
+    totalAmount = 0,
+  ): Order => {
     const order = new Order();
+    order.customerId = customerId;
     order.orderNumber = orderNumber;
     order.status = status;
     order.totalAmount = totalAmount;
@@ -108,9 +126,10 @@ describe('OrderRepositoryImpl (Integration)', () => {
     it('should return order with items for active order', async () => {
       const category = await createCategory();
       const product = await createProduct(category.id);
+      const customer = await createCustomer();
 
       const createdOrder = await repository.createWithItems(
-        createOrderEntity(`ORD-${Date.now()}-find`, OrderStatus.PENDING, 20),
+        createOrderEntity(customer.id, `ORD-${Date.now()}-find`, OrderStatus.PENDING, 20),
         [createOrderItemEntity(product.id, 2, 10, 20)],
       );
 
@@ -125,6 +144,7 @@ describe('OrderRepositoryImpl (Integration)', () => {
     it('should not return soft-deleted order', async () => {
       const savedOrder = await orderOrmRepo.save(
         orderOrmRepo.create({
+          customerId: (await createCustomer()).id,
           orderNumber: `ORD-${Date.now()}-soft-deleted`,
           status: OrderStatus.PENDING,
           totalAmount: 0,
@@ -141,8 +161,10 @@ describe('OrderRepositoryImpl (Integration)', () => {
 
   describe('list', () => {
     it('should apply filters and return paginated result metadata', async () => {
+      const customer = await createCustomer();
       const orderA = await orderOrmRepo.save(
         orderOrmRepo.create({
+          customerId: customer.id,
           orderNumber: `ORD-${Date.now()}-A`,
           status: OrderStatus.PENDING,
           totalAmount: 100,
@@ -150,6 +172,7 @@ describe('OrderRepositoryImpl (Integration)', () => {
       );
       const orderB = await orderOrmRepo.save(
         orderOrmRepo.create({
+          customerId: customer.id,
           orderNumber: `ORD-${Date.now()}-B`,
           status: OrderStatus.PENDING,
           totalAmount: 120,
@@ -157,6 +180,7 @@ describe('OrderRepositoryImpl (Integration)', () => {
       );
       await orderOrmRepo.save(
         orderOrmRepo.create({
+          customerId: customer.id,
           orderNumber: `ORD-${Date.now()}-C`,
           status: OrderStatus.COMPLETED,
           totalAmount: 200,
@@ -204,8 +228,10 @@ describe('OrderRepositoryImpl (Integration)', () => {
     });
 
     it('should not include soft-deleted orders in list', async () => {
+      const customer = await createCustomer();
       const order = await orderOrmRepo.save(
         orderOrmRepo.create({
+          customerId: customer.id,
           orderNumber: `ORD-${Date.now()}-deleted-list`,
           status: OrderStatus.PENDING,
           totalAmount: 10,
@@ -226,9 +252,10 @@ describe('OrderRepositoryImpl (Integration)', () => {
       const category = await createCategory();
       const productA = await createProduct(category.id, 12);
       const productB = await createProduct(category.id, 8);
+      const customer = await createCustomer();
 
       const result = await repository.createWithItems(
-        createOrderEntity(`ORD-${Date.now()}-tx-ok`, OrderStatus.PENDING, 28),
+        createOrderEntity(customer.id, `ORD-${Date.now()}-tx-ok`, OrderStatus.PENDING, 28),
         [
           createOrderItemEntity(productA.id, 1, 12, 12),
           createOrderItemEntity(productB.id, 2, 8, 16),
@@ -248,11 +275,12 @@ describe('OrderRepositoryImpl (Integration)', () => {
     it('should rollback entire transaction when item persistence fails', async () => {
       const category = await createCategory();
       const validProduct = await createProduct(category.id, 15);
+      const customer = await createCustomer();
       const invalidProductId = '00000000-0000-0000-0000-000000000000';
 
       await expect(
         repository.createWithItems(
-          createOrderEntity(`ORD-${Date.now()}-tx-fail`, OrderStatus.PENDING, 30),
+          createOrderEntity(customer.id, `ORD-${Date.now()}-tx-fail`, OrderStatus.PENDING, 30),
           [
             createOrderItemEntity(validProduct.id, 1, 15, 15),
             createOrderItemEntity(invalidProductId, 1, 15, 15),
@@ -270,8 +298,10 @@ describe('OrderRepositoryImpl (Integration)', () => {
 
   describe('updateStatus', () => {
     it('should update order status for active order', async () => {
+      const customer = await createCustomer();
       const order = await orderOrmRepo.save(
         orderOrmRepo.create({
+          customerId: customer.id,
           orderNumber: `ORD-${Date.now()}-status`,
           status: OrderStatus.PENDING,
           totalAmount: 0,

--- a/apps/api/src/repositories/order.repository.impl.ts
+++ b/apps/api/src/repositories/order.repository.impl.ts
@@ -94,6 +94,7 @@ export class OrderRepositoryImpl implements IOrderRepository {
 
       const savedOrder = await orderRepository.save(
         orderRepository.create({
+          customerId: order.customerId,
           orderNumber: order.orderNumber,
           status: order.status,
           totalAmount: order.totalAmount,

--- a/libs/domain/src/entities/customer.entity.ts
+++ b/libs/domain/src/entities/customer.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, Column, OneToMany } from 'typeorm';
+
+import { BaseEntity } from './base.entity';
+import { Order } from './order.entity';
+
+/**
+ * Domain entity representing a customer who places orders.
+ */
+@Entity('customers')
+export class Customer extends BaseEntity {
+  /**
+   * Full name of the customer.
+   */
+  @Column({ type: 'varchar', length: 100, name: 'name' })
+  name!: string;
+
+  /**
+   * Unique email address of the customer.
+   */
+  @Column({ type: 'varchar', length: 255, name: 'email' })
+  email!: string;
+
+  /**
+   * Unique phone number of the customer.
+   */
+  @Column({ type: 'varchar', length: 20, name: 'phone' })
+  phone!: string;
+
+  /**
+   * Orders placed by this customer.
+   */
+  @OneToMany(() => Order, (order) => order.customer)
+  orders!: Order[];
+}

--- a/libs/domain/src/entities/order.entity.ts
+++ b/libs/domain/src/entities/order.entity.ts
@@ -1,8 +1,9 @@
-import { Entity, Column, OneToMany } from 'typeorm';
+import { Entity, Column, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
 
 import { BaseEntity } from './base.entity';
 import { OrderStatus } from '../enums/order-status.enum';
 import { OrderItem } from './order-item.entity';
+import { Customer } from './customer.entity';
 
 /**
  * Domain entity representing a customer order.
@@ -13,6 +14,12 @@ import { OrderItem } from './order-item.entity';
  */
 @Entity('orders')
 export class Order extends BaseEntity {
+  /**
+   * Foreign key referencing the customer who placed this order.
+   */
+  @Column({ type: 'uuid', name: 'customer_id' })
+  customerId!: string;
+
   /**
    * Business-readable unique order identifier (e.g. "ORD-2024-00001").
    */
@@ -38,4 +45,11 @@ export class Order extends BaseEntity {
    */
   @OneToMany(() => OrderItem, (item) => item.order)
   items!: OrderItem[];
+
+  /**
+   * Customer who placed this order.
+   */
+  @ManyToOne(() => Customer, (customer) => customer.orders)
+  @JoinColumn({ name: 'customer_id' })
+  customer!: Customer;
 }

--- a/libs/domain/src/errors/customer-not-found.error.ts
+++ b/libs/domain/src/errors/customer-not-found.error.ts
@@ -1,0 +1,10 @@
+import { DomainError } from './domain.error';
+
+/**
+ * Thrown when a requested customer cannot be found in the data store.
+ */
+export class CustomerNotFoundException extends DomainError {
+  constructor() {
+    super('Cliente não encontrado');
+  }
+}

--- a/libs/domain/src/index.ts
+++ b/libs/domain/src/index.ts
@@ -1,30 +1,28 @@
-// Entities
 export { BaseEntity } from './entities/base.entity';
 export { Category } from './entities/category.entity';
 export { Product } from './entities/product.entity';
 export { Stock } from './entities/stock.entity';
 export { Order } from './entities/order.entity';
 export { OrderItem } from './entities/order-item.entity';
+export { Customer } from './entities/customer.entity';
 
-// Enums
 export { OrderStatus } from './enums/order-status.enum';
 
-// Errors
 export { DomainError } from './errors/domain.error';
 export { ProductNotFoundException } from './errors/product-not-found.error';
 export { CategoryNotFoundException } from './errors/category-not-found.error';
 export { InsufficientStockError } from './errors/insufficient-stock.error';
 export { OrderNotFoundException } from './errors/order-not-found.error';
 export { InvalidOrderStatusTransitionError } from './errors/invalid-order-status-transition.error';
+export { CustomerNotFoundException } from './errors/customer-not-found.error';
 
-// Repositories
 export type { ICategoryRepository, CategoryListParams } from './repositories/category.repository';
 export type { IProductRepository, ProductListParams } from './repositories/product.repository';
 export type { IStockRepository, StockListParams } from './repositories/stock.repository';
 export type { IOrderRepository, OrderListParams } from './repositories/order.repository';
 export type { IOrderItemRepository } from './repositories/order-item.repository';
+export type { ICustomerRepository } from './repositories/customer.repository';
 
-// Services
 export { CategoryService } from './services/category.service';
 export type { CreateCategoryDTO, UpdateCategoryDTO } from './services/category.service';
 export { ProductService } from './services/product.service';
@@ -32,7 +30,6 @@ export { StockService } from './services/stock.service';
 export { OrderService } from './services/order.service';
 export type { CreateOrderItemDTO, OrderItemData } from './services/order.service';
 
-// Category Use Cases
 export { CreateCategoryUseCase } from './use-cases/category/create-category.usecase';
 export { ListCategoriesUseCase } from './use-cases/category/list-categories.usecase';
 export type { ListCategoriesDTO } from './use-cases/category/list-categories.usecase';
@@ -41,7 +38,6 @@ export { UpdateCategoryUseCase } from './use-cases/category/update-category.usec
 export type { UpdateCategoryInput } from './use-cases/category/update-category.usecase';
 export { DeleteCategoryUseCase } from './use-cases/category/delete-category.usecase';
 
-// Product Use Cases
 export { CreateProductUseCase } from './use-cases/product/create-product.usecase';
 export type { CreateProductDTO } from './use-cases/product/create-product.usecase';
 export { ListProductsUseCase } from './use-cases/product/list-products.usecase';
@@ -50,12 +46,10 @@ export { UpdateProductUseCase } from './use-cases/product/update-product.usecase
 export type { UpdateProductDTO } from './use-cases/product/update-product.usecase';
 export { DeleteProductUseCase } from './use-cases/product/delete-product.usecase';
 
-// Stock Use Cases
 export { GetStockUseCase } from './use-cases/stock/get-stock.usecase';
 export { UpdateStockUseCase } from './use-cases/stock/update-stock.usecase';
 export type { UpdateStockDTO } from './use-cases/stock/update-stock.usecase';
 
-// Order Use Cases
 export { CreateOrderUseCase } from './use-cases/orders/create-order.usecase';
 export type { CreateOrderDTO } from './use-cases/orders/create-order.usecase';
 export { GetOrderUseCase } from './use-cases/orders/get-order.usecase';

--- a/libs/domain/src/repositories/customer.repository.ts
+++ b/libs/domain/src/repositories/customer.repository.ts
@@ -1,0 +1,26 @@
+import { Customer } from '../entities/customer.entity';
+
+/**
+ * Repository contract for Customer operations.
+ */
+export interface ICustomerRepository {
+  /**
+   * Retrieves a customer by its unique identifier.
+   */
+  findById(id: string): Promise<Customer | null>;
+
+  /**
+   * Retrieves a customer by its unique email address.
+   */
+  findByEmail(email: string): Promise<Customer | null>;
+
+  /**
+   * Persists the provided customer.
+   */
+  save(customer: Customer): Promise<Customer>;
+
+  /**
+   * Soft-deletes a customer by its identifier.
+   */
+  softDelete(id: string): Promise<void>;
+}

--- a/libs/domain/src/repositories/repositories.spec.ts
+++ b/libs/domain/src/repositories/repositories.spec.ts
@@ -1,12 +1,14 @@
 import { PaginatedResult } from '@shared/types/pagination.types';
 
 import { Category } from '../entities/category.entity';
+import { Customer } from '../entities/customer.entity';
 import { Order } from '../entities/order.entity';
 import { OrderItem } from '../entities/order-item.entity';
 import { Product } from '../entities/product.entity';
 import { Stock } from '../entities/stock.entity';
 import { OrderStatus } from '../enums/order-status.enum';
 import { ICategoryRepository, CategoryListParams } from './category.repository';
+import { ICustomerRepository } from './customer.repository';
 import { IOrderRepository, OrderListParams } from './order.repository';
 import { IOrderItemRepository } from './order-item.repository';
 import { IProductRepository, ProductListParams } from './product.repository';
@@ -123,6 +125,29 @@ describe('Repository contracts', () => {
 
     const repo: IOrderRepository = new DummyOrderRepository();
     expect(repo).toBeInstanceOf(DummyOrderRepository);
+  });
+
+  it('Customer repository contract is satisfiable', async () => {
+    class DummyCustomerRepository implements ICustomerRepository {
+      async findById(): Promise<Customer | null> {
+        return null;
+      }
+
+      async findByEmail(): Promise<Customer | null> {
+        return null;
+      }
+
+      async save(customer: Customer): Promise<Customer> {
+        return customer;
+      }
+
+      async softDelete(): Promise<void> {
+        return undefined;
+      }
+    }
+
+    const repo: ICustomerRepository = new DummyCustomerRepository();
+    expect(repo).toBeInstanceOf(DummyCustomerRepository);
   });
 
   it('Order item repository contract is satisfiable', async () => {

--- a/libs/domain/src/services/order.service.spec.ts
+++ b/libs/domain/src/services/order.service.spec.ts
@@ -16,6 +16,7 @@ describe('OrderService', () => {
   const buildOrder = (overrides: Partial<Order> = {}): Order =>
     ({
       id: 'order-1',
+      customerId: 'customer-1',
       orderNumber: 'ORD-1711234567890-a3f2',
       status: OrderStatus.PENDING,
       totalAmount: 100,
@@ -54,20 +55,15 @@ describe('OrderService', () => {
 
   describe('generateOrderNumber', () => {
     it('should return a string matching ORD-{digits}-{4-hex-chars} pattern', () => {
-      // Act
       const result = service.generateOrderNumber();
 
-      // Assert
       expect(result).toMatch(/^ORD-\d+-[0-9a-f]{4}$/);
     });
 
     it('should return unique values on consecutive calls', () => {
-      // Act
       const first = service.generateOrderNumber();
       const second = service.generateOrderNumber();
 
-      // Assert — statistically near-impossible to collide across two calls
-      // (timestamp differs or random hex differs)
       expect(typeof first).toBe('string');
       expect(typeof second).toBe('string');
     });
@@ -75,23 +71,18 @@ describe('OrderService', () => {
 
   describe('findOrFail', () => {
     it('should return the order when it exists', async () => {
-      // Arrange
       const order = buildOrder();
       mockOrderRepository.findById.mockResolvedValue(order);
 
-      // Act
       const result = await service.findOrFail('order-1');
 
-      // Assert
       expect(result).toEqual(order);
       expect(mockOrderRepository.findById).toHaveBeenCalledWith('order-1');
     });
 
     it('should throw OrderNotFoundException when the order does not exist', async () => {
-      // Arrange
       mockOrderRepository.findById.mockResolvedValue(null);
 
-      // Act & Assert
       await expect(service.findOrFail('non-existent')).rejects.toThrow(OrderNotFoundException);
       expect(mockOrderRepository.findById).toHaveBeenCalledWith('non-existent');
     });
@@ -159,7 +150,6 @@ describe('OrderService', () => {
     });
 
     it('should include the from and to statuses in the error message', () => {
-      // Act & Assert
       expect(() =>
         service.validateStatusTransition(OrderStatus.COMPLETED, OrderStatus.PROCESSING),
       ).toThrow(
@@ -178,7 +168,6 @@ describe('OrderService', () => {
 
   describe('calculateOrderItems', () => {
     it('should calculate unitPrice and subtotal correctly for each item', () => {
-      // Arrange
       const products = [
         buildProduct({ id: 'prod-1', price: 8.5 }),
         buildProduct({ id: 'prod-2', name: 'Guaraná 2L', price: 7.0 }),
@@ -188,10 +177,8 @@ describe('OrderService', () => {
         { productId: 'prod-2', quantity: 3 },
       ];
 
-      // Act
       const result = service.calculateOrderItems(items, products);
 
-      // Assert
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual<OrderItemData>({
         productId: 'prod-1',
@@ -208,23 +195,18 @@ describe('OrderService', () => {
     });
 
     it('should throw ProductNotFoundException when a product referenced by an item is not in the products list', () => {
-      // Arrange
       const products = [buildProduct({ id: 'prod-1' })];
       const items: CreateOrderItemDTO[] = [{ productId: 'non-existent-prod', quantity: 1 }];
 
-      // Act & Assert
       expect(() => service.calculateOrderItems(items, products)).toThrow(ProductNotFoundException);
     });
 
     it('should handle a single item correctly', () => {
-      // Arrange
       const products = [buildProduct({ id: 'prod-1', price: 10.0 })];
       const items: CreateOrderItemDTO[] = [{ productId: 'prod-1', quantity: 5 }];
 
-      // Act
       const result = service.calculateOrderItems(items, products);
 
-      // Assert
       expect(result).toHaveLength(1);
       expect(result[0].subtotal).toBe(50.0);
       expect(result[0].unitPrice).toBe(10.0);
@@ -233,37 +215,29 @@ describe('OrderService', () => {
 
   describe('calculateTotal', () => {
     it('should sum all subtotals correctly', () => {
-      // Arrange
       const items: OrderItemData[] = [
         { productId: 'prod-1', quantity: 2, unitPrice: 8.5, subtotal: 17.0 },
         { productId: 'prod-2', quantity: 3, unitPrice: 7.0, subtotal: 21.0 },
       ];
 
-      // Act
       const result = service.calculateTotal(items);
 
-      // Assert
       expect(result).toBe(38.0);
     });
 
     it('should return 0 for an empty array', () => {
-      // Act
       const result = service.calculateTotal([]);
 
-      // Assert
       expect(result).toBe(0);
     });
 
     it('should return the single subtotal when only one item is present', () => {
-      // Arrange
       const items: OrderItemData[] = [
         { productId: 'prod-1', quantity: 1, unitPrice: 15.0, subtotal: 15.0 },
       ];
 
-      // Act
       const result = service.calculateTotal(items);
 
-      // Assert
       expect(result).toBe(15.0);
     });
   });

--- a/libs/domain/src/use-cases/orders/cancel-order.usecase.spec.ts
+++ b/libs/domain/src/use-cases/orders/cancel-order.usecase.spec.ts
@@ -16,6 +16,7 @@ describe('CancelOrderUseCase', () => {
   const buildOrder = (overrides: Partial<Order> = {}): Order =>
     ({
       id: 'order-1',
+      customerId: 'customer-1',
       orderNumber: 'ORD-1711234567890-a3f2',
       status: OrderStatus.PENDING,
       totalAmount: 50.0,
@@ -50,7 +51,6 @@ describe('CancelOrderUseCase', () => {
 
   describe('execute', () => {
     it('should cancel a PENDING order successfully', async () => {
-      // Arrange
       const pendingOrder = buildOrder({ status: OrderStatus.PENDING });
       const cancelledOrder = buildOrder({ status: OrderStatus.CANCELLED });
 
@@ -58,10 +58,8 @@ describe('CancelOrderUseCase', () => {
       mockOrderService.validateStatusTransition.mockReturnValue(undefined);
       mockOrderRepository.updateStatus.mockResolvedValue(cancelledOrder);
 
-      // Act
       const result = await useCase.execute('order-1');
 
-      // Assert
       expect(result).toEqual(cancelledOrder);
       expect(mockOrderService.findOrFail).toHaveBeenCalledWith('order-1');
       expect(mockOrderService.validateStatusTransition).toHaveBeenCalledWith(
@@ -75,7 +73,6 @@ describe('CancelOrderUseCase', () => {
     });
 
     it('should cancel a PROCESSING order successfully', async () => {
-      // Arrange
       const processingOrder = buildOrder({ status: OrderStatus.PROCESSING });
       const cancelledOrder = buildOrder({ status: OrderStatus.CANCELLED });
 
@@ -83,10 +80,8 @@ describe('CancelOrderUseCase', () => {
       mockOrderService.validateStatusTransition.mockReturnValue(undefined);
       mockOrderRepository.updateStatus.mockResolvedValue(cancelledOrder);
 
-      // Act
       const result = await useCase.execute('order-1');
 
-      // Assert
       expect(result).toEqual(cancelledOrder);
       expect(mockOrderService.validateStatusTransition).toHaveBeenCalledWith(
         OrderStatus.PROCESSING,
@@ -99,17 +94,14 @@ describe('CancelOrderUseCase', () => {
     });
 
     it('should throw OrderNotFoundException when the order does not exist', async () => {
-      // Arrange
       mockOrderService.findOrFail.mockRejectedValue(new OrderNotFoundException());
 
-      // Act & Assert
       await expect(useCase.execute('non-existent')).rejects.toThrow(OrderNotFoundException);
       expect(mockOrderService.validateStatusTransition).not.toHaveBeenCalled();
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
     it('should throw InvalidOrderStatusTransitionError when the order is already COMPLETED', async () => {
-      // Arrange
       const completedOrder = buildOrder({ status: OrderStatus.COMPLETED });
 
       mockOrderService.findOrFail.mockResolvedValue(completedOrder);
@@ -117,13 +109,11 @@ describe('CancelOrderUseCase', () => {
         throw new InvalidOrderStatusTransitionError(OrderStatus.COMPLETED, OrderStatus.CANCELLED);
       });
 
-      // Act & Assert
       await expect(useCase.execute('order-1')).rejects.toThrow(InvalidOrderStatusTransitionError);
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
     it('should throw InvalidOrderStatusTransitionError when the order is already CANCELLED', async () => {
-      // Arrange
       const cancelledOrder = buildOrder({ status: OrderStatus.CANCELLED });
 
       mockOrderService.findOrFail.mockResolvedValue(cancelledOrder);
@@ -131,13 +121,11 @@ describe('CancelOrderUseCase', () => {
         throw new InvalidOrderStatusTransitionError(OrderStatus.CANCELLED, OrderStatus.CANCELLED);
       });
 
-      // Act & Assert
       await expect(useCase.execute('order-1')).rejects.toThrow(InvalidOrderStatusTransitionError);
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
     it('should always pass CANCELLED as the target status to validateStatusTransition', async () => {
-      // Arrange
       const pendingOrder = buildOrder({ status: OrderStatus.PENDING });
       mockOrderService.findOrFail.mockResolvedValue(pendingOrder);
       mockOrderService.validateStatusTransition.mockReturnValue(undefined);
@@ -145,10 +133,8 @@ describe('CancelOrderUseCase', () => {
         buildOrder({ status: OrderStatus.CANCELLED }),
       );
 
-      // Act
       await useCase.execute('order-1');
 
-      // Assert
       expect(mockOrderService.validateStatusTransition).toHaveBeenCalledWith(
         expect.any(String),
         OrderStatus.CANCELLED,

--- a/libs/domain/src/use-cases/orders/create-order.usecase.spec.ts
+++ b/libs/domain/src/use-cases/orders/create-order.usecase.spec.ts
@@ -1,12 +1,15 @@
 import 'reflect-metadata';
 
 import { CreateOrderUseCase, CreateOrderDTO } from './create-order.usecase';
+import { ICustomerRepository } from '../../repositories/customer.repository';
 import { IOrderRepository } from '../../repositories/order.repository';
 import { IProductRepository } from '../../repositories/product.repository';
 import { StockService } from '../../services/stock.service';
 import { OrderService, OrderItemData } from '../../services/order.service';
+import { CustomerNotFoundException } from '../../errors/customer-not-found.error';
 import { ProductNotFoundException } from '../../errors/product-not-found.error';
 import { InsufficientStockError } from '../../errors/insufficient-stock.error';
+import { Customer } from '../../entities/customer.entity';
 import { Order } from '../../entities/order.entity';
 import { OrderItem } from '../../entities/order-item.entity';
 import { Product } from '../../entities/product.entity';
@@ -14,6 +17,7 @@ import { OrderStatus } from '../../enums/order-status.enum';
 
 describe('CreateOrderUseCase', () => {
   let useCase: CreateOrderUseCase;
+  let mockCustomerRepository: jest.Mocked<ICustomerRepository>;
   let mockOrderRepository: jest.Mocked<IOrderRepository>;
   let mockProductRepository: jest.Mocked<IProductRepository>;
   let mockStockService: jest.Mocked<StockService>;
@@ -31,9 +35,21 @@ describe('CreateOrderUseCase', () => {
       ...overrides,
     }) as Product;
 
+  const buildCustomer = (overrides: Partial<Customer> = {}): Customer =>
+    ({
+      id: 'customer-1',
+      name: 'João Silva',
+      email: 'joao@teste.com',
+      phone: '11999990000',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    }) as Customer;
+
   const buildSavedOrder = (overrides: Partial<Order> = {}): Order =>
     ({
       id: 'order-new',
+      customerId: 'customer-1',
       orderNumber: 'ORD-1711234567890-a3f2',
       status: OrderStatus.PENDING,
       totalAmount: 17.0,
@@ -44,6 +60,13 @@ describe('CreateOrderUseCase', () => {
     }) as Order;
 
   beforeEach(() => {
+    mockCustomerRepository = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+      softDelete: jest.fn(),
+    } as jest.Mocked<ICustomerRepository>;
+
     mockOrderRepository = {
       list: jest.fn(),
       findById: jest.fn(),
@@ -74,6 +97,7 @@ describe('CreateOrderUseCase', () => {
 
     useCase = new CreateOrderUseCase(
       mockOrderRepository,
+      mockCustomerRepository,
       mockProductRepository,
       mockStockService,
       mockOrderService,
@@ -86,8 +110,8 @@ describe('CreateOrderUseCase', () => {
 
   describe('execute', () => {
     it('should create order successfully with valid items', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [{ productId: 'prod-1', quantity: 2 }],
       };
       const products = [buildProduct({ id: 'prod-1', price: 8.5 })];
@@ -96,6 +120,7 @@ describe('CreateOrderUseCase', () => {
       ];
       const savedOrder = buildSavedOrder({ totalAmount: 17.0 });
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue(products);
       mockStockService.validateSufficientStock.mockResolvedValue(undefined);
       mockOrderService.calculateOrderItems.mockReturnValue(calculatedItems);
@@ -103,11 +128,10 @@ describe('CreateOrderUseCase', () => {
       mockOrderService.generateOrderNumber.mockReturnValue('ORD-1711234567890-a3f2');
       mockOrderRepository.createWithItems.mockResolvedValue(savedOrder);
 
-      // Act
       const result = await useCase.execute(dto);
 
-      // Assert
       expect(result).toEqual(savedOrder);
+      expect(mockCustomerRepository.findById).toHaveBeenCalledWith('customer-1');
       expect(mockProductRepository.findByIds).toHaveBeenCalledWith(['prod-1']);
       expect(mockStockService.validateSufficientStock).toHaveBeenCalledWith('prod-1', 2);
       expect(mockOrderService.calculateOrderItems).toHaveBeenCalledWith(dto.items, products);
@@ -116,8 +140,8 @@ describe('CreateOrderUseCase', () => {
     });
 
     it('should set status to PENDING on creation', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [{ productId: 'prod-1', quantity: 1 }],
       };
       const products = [buildProduct({ id: 'prod-1' })];
@@ -126,6 +150,7 @@ describe('CreateOrderUseCase', () => {
       ];
       const savedOrder = buildSavedOrder({ status: OrderStatus.PENDING });
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue(products);
       mockStockService.validateSufficientStock.mockResolvedValue(undefined);
       mockOrderService.calculateOrderItems.mockReturnValue(calculatedItems);
@@ -133,19 +158,17 @@ describe('CreateOrderUseCase', () => {
       mockOrderService.generateOrderNumber.mockReturnValue('ORD-111-aaaa');
       mockOrderRepository.createWithItems.mockResolvedValue(savedOrder);
 
-      // Act
       await useCase.execute(dto);
 
-      // Assert
       expect(mockOrderRepository.createWithItems).toHaveBeenCalledWith(
-        expect.objectContaining({ status: OrderStatus.PENDING }),
+        expect.objectContaining({ customerId: 'customer-1', status: OrderStatus.PENDING }),
         expect.any(Array),
       );
     });
 
     it('should call createWithItems with correct order and items data', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [
           { productId: 'prod-1', quantity: 2 },
           { productId: 'prod-2', quantity: 1 },
@@ -161,6 +184,7 @@ describe('CreateOrderUseCase', () => {
       ];
       const savedOrder = buildSavedOrder({ totalAmount: 24.0 });
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue(products);
       mockStockService.validateSufficientStock.mockResolvedValue(undefined);
       mockOrderService.calculateOrderItems.mockReturnValue(calculatedItems);
@@ -168,12 +192,11 @@ describe('CreateOrderUseCase', () => {
       mockOrderService.generateOrderNumber.mockReturnValue('ORD-111-bbbb');
       mockOrderRepository.createWithItems.mockResolvedValue(savedOrder);
 
-      // Act
       await useCase.execute(dto);
 
-      // Assert
       expect(mockOrderRepository.createWithItems).toHaveBeenCalledWith(
         expect.objectContaining({
+          customerId: 'customer-1',
           orderNumber: 'ORD-111-bbbb',
           status: OrderStatus.PENDING,
           totalAmount: 24.0,
@@ -196,54 +219,54 @@ describe('CreateOrderUseCase', () => {
     });
 
     it('should throw ProductNotFoundException when a product does not exist', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [{ productId: 'non-existent-prod', quantity: 1 }],
       };
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue([]);
 
-      // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow(ProductNotFoundException);
       expect(mockStockService.validateSufficientStock).not.toHaveBeenCalled();
       expect(mockOrderRepository.createWithItems).not.toHaveBeenCalled();
     });
 
     it('should throw ProductNotFoundException when a product is inactive', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [{ productId: 'prod-inactive', quantity: 1 }],
       };
       const inactiveProduct = buildProduct({ id: 'prod-inactive', isActive: false });
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue([inactiveProduct]);
 
-      // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow(ProductNotFoundException);
       expect(mockStockService.validateSufficientStock).not.toHaveBeenCalled();
       expect(mockOrderRepository.createWithItems).not.toHaveBeenCalled();
     });
 
     it('should throw InsufficientStockError when stock is insufficient', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [{ productId: 'prod-1', quantity: 999 }],
       };
       const products = [buildProduct({ id: 'prod-1' })];
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue(products);
       mockStockService.validateSufficientStock.mockRejectedValue(
         new InsufficientStockError('Coca-Cola 2L'),
       );
 
-      // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow(InsufficientStockError);
       expect(mockOrderRepository.createWithItems).not.toHaveBeenCalled();
     });
 
     it('should build OrderItem entities with the correct data before persisting', async () => {
-      // Arrange
       const dto: CreateOrderDTO = {
+        customerId: 'customer-1',
         items: [{ productId: 'prod-1', quantity: 3 }],
       };
       const products = [buildProduct({ id: 'prod-1', price: 10.0 })];
@@ -251,6 +274,7 @@ describe('CreateOrderUseCase', () => {
         { productId: 'prod-1', quantity: 3, unitPrice: 10.0, subtotal: 30.0 },
       ];
 
+      mockCustomerRepository.findById.mockResolvedValue(buildCustomer());
       mockProductRepository.findByIds.mockResolvedValue(products);
       mockStockService.validateSufficientStock.mockResolvedValue(undefined);
       mockOrderService.calculateOrderItems.mockReturnValue(calculatedItems);
@@ -258,10 +282,8 @@ describe('CreateOrderUseCase', () => {
       mockOrderService.generateOrderNumber.mockReturnValue('ORD-222-cccc');
       mockOrderRepository.createWithItems.mockResolvedValue(buildSavedOrder());
 
-      // Act
       await useCase.execute(dto);
 
-      // Assert
       const [, passedItems] = mockOrderRepository.createWithItems.mock.calls[0] as [
         Order,
         OrderItem[],
@@ -272,6 +294,20 @@ describe('CreateOrderUseCase', () => {
       expect(passedItems[0].quantity).toBe(3);
       expect(passedItems[0].unitPrice).toBe(10.0);
       expect(passedItems[0].subtotal).toBe(30.0);
+    });
+
+    it('should throw CustomerNotFoundException when customer does not exist', async () => {
+      const dto: CreateOrderDTO = {
+        customerId: 'customer-missing',
+        items: [{ productId: 'prod-1', quantity: 1 }],
+      };
+
+      mockCustomerRepository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute(dto)).rejects.toThrow(CustomerNotFoundException);
+      expect(mockProductRepository.findByIds).not.toHaveBeenCalled();
+      expect(mockStockService.validateSufficientStock).not.toHaveBeenCalled();
+      expect(mockOrderRepository.createWithItems).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/domain/src/use-cases/orders/create-order.usecase.ts
+++ b/libs/domain/src/use-cases/orders/create-order.usecase.ts
@@ -3,7 +3,9 @@ import { injectable, inject } from 'tsyringe';
 import { Order } from '../../entities/order.entity';
 import { OrderItem } from '../../entities/order-item.entity';
 import { OrderStatus } from '../../enums/order-status.enum';
+import { CustomerNotFoundException } from '../../errors/customer-not-found.error';
 import { ProductNotFoundException } from '../../errors/product-not-found.error';
+import { ICustomerRepository } from '../../repositories/customer.repository';
 import { IOrderRepository } from '../../repositories/order.repository';
 import { IProductRepository } from '../../repositories/product.repository';
 import { OrderService, CreateOrderItemDTO } from '../../services/order.service';
@@ -13,6 +15,8 @@ import { StockService } from '../../services/stock.service';
  * Input data required to create a new order.
  */
 export interface CreateOrderDTO {
+  /** UUID of the customer placing the order. */
+  customerId: string;
   /** List of items to include in the order. Must contain at least one item. */
   items: CreateOrderItemDTO[];
 }
@@ -29,6 +33,8 @@ export class CreateOrderUseCase {
   constructor(
     @inject('IOrderRepository')
     private readonly orderRepository: IOrderRepository,
+    @inject('ICustomerRepository')
+    private readonly customerRepository: ICustomerRepository,
     @inject('IProductRepository')
     private readonly productRepository: IProductRepository,
     @inject('StockService')
@@ -46,39 +52,40 @@ export class CreateOrderUseCase {
    * @throws {InsufficientStockError} When available stock is below the requested quantity for any item.
    */
   async execute(dto: CreateOrderDTO): Promise<Order> {
+    const customer = await this.customerRepository.findById(dto.customerId);
+
+    if (!customer) {
+      throw new CustomerNotFoundException();
+    }
+
     const productIds = dto.items.map((item) => item.productId);
     const products = await this.productRepository.findByIds(productIds);
 
-    // Validate all products exist
     const productMap = new Map(products.map((p) => [p.id, p]));
     for (const item of dto.items) {
       const product = productMap.get(item.productId);
       if (!product) {
         throw new ProductNotFoundException();
       }
-      // Validate product is active
       if (!product.isActive) {
         throw new ProductNotFoundException();
       }
     }
 
-    // Validate stock for each item
     for (const item of dto.items) {
       await this.stockService.validateSufficientStock(item.productId, item.quantity);
     }
 
-    // Calculate price snapshots and subtotals
     const orderItemsData = this.orderService.calculateOrderItems(dto.items, products);
     const totalAmount = this.orderService.calculateTotal(orderItemsData);
     const orderNumber = this.orderService.generateOrderNumber();
 
-    // Build Order entity
     const order = new Order();
+    order.customerId = dto.customerId;
     order.orderNumber = orderNumber;
     order.status = OrderStatus.PENDING;
     order.totalAmount = totalAmount;
 
-    // Build OrderItem entities
     const orderItems = orderItemsData.map((data) => {
       const item = new OrderItem();
       item.productId = data.productId;

--- a/libs/domain/src/use-cases/orders/get-order.usecase.spec.ts
+++ b/libs/domain/src/use-cases/orders/get-order.usecase.spec.ts
@@ -13,6 +13,7 @@ describe('GetOrderUseCase', () => {
   const buildOrder = (overrides: Partial<Order> = {}): Order =>
     ({
       id: 'order-1',
+      customerId: 'customer-1',
       orderNumber: 'ORD-1711234567890-a3f2',
       status: OrderStatus.PENDING,
       totalAmount: 50.0,
@@ -40,23 +41,18 @@ describe('GetOrderUseCase', () => {
 
   describe('execute', () => {
     it('should return the order when it exists', async () => {
-      // Arrange
       const order = buildOrder();
       mockOrderService.findOrFail.mockResolvedValue(order);
 
-      // Act
       const result = await useCase.execute('order-1');
 
-      // Assert
       expect(result).toEqual(order);
       expect(mockOrderService.findOrFail).toHaveBeenCalledWith('order-1');
     });
 
     it('should throw OrderNotFoundException when the order does not exist', async () => {
-      // Arrange
       mockOrderService.findOrFail.mockRejectedValue(new OrderNotFoundException());
 
-      // Act & Assert
       await expect(useCase.execute('non-existent')).rejects.toThrow(OrderNotFoundException);
       expect(mockOrderService.findOrFail).toHaveBeenCalledWith('non-existent');
     });

--- a/libs/domain/src/use-cases/orders/list-orders.usecase.spec.ts
+++ b/libs/domain/src/use-cases/orders/list-orders.usecase.spec.ts
@@ -13,6 +13,7 @@ describe('ListOrdersUseCase', () => {
   const buildOrder = (overrides: Partial<Order> = {}): Order =>
     ({
       id: 'order-1',
+      customerId: 'customer-1',
       orderNumber: 'ORD-1711234567890-a3f2',
       status: OrderStatus.PENDING,
       totalAmount: 50.0,
@@ -49,39 +50,32 @@ describe('ListOrdersUseCase', () => {
 
   describe('execute', () => {
     it('should return paginated orders when called with default params', async () => {
-      // Arrange
       const orders = [buildOrder(), buildOrder({ id: 'order-2', orderNumber: 'ORD-222-bbbb' })];
       const paginatedResult = buildPaginatedResult(orders);
       const params: OrderListParams = { page: 1, limit: 10 };
 
       mockOrderRepository.list.mockResolvedValue(paginatedResult);
 
-      // Act
       const result = await useCase.execute(params);
 
-      // Assert
       expect(result).toEqual(paginatedResult);
       expect(mockOrderRepository.list).toHaveBeenCalledWith(params);
     });
 
     it('should forward status filter to the repository', async () => {
-      // Arrange
       const params: OrderListParams = { page: 1, limit: 10, status: OrderStatus.PROCESSING };
       const paginatedResult = buildPaginatedResult([]);
 
       mockOrderRepository.list.mockResolvedValue(paginatedResult);
 
-      // Act
       await useCase.execute(params);
 
-      // Assert
       expect(mockOrderRepository.list).toHaveBeenCalledWith(
         expect.objectContaining({ status: OrderStatus.PROCESSING }),
       );
     });
 
     it('should forward date range filters to the repository', async () => {
-      // Arrange
       const createdAfter = new Date('2024-01-01');
       const createdBefore = new Date('2024-12-31');
       const params: OrderListParams = { page: 1, limit: 10, createdAfter, createdBefore };
@@ -89,26 +83,21 @@ describe('ListOrdersUseCase', () => {
 
       mockOrderRepository.list.mockResolvedValue(paginatedResult);
 
-      // Act
       await useCase.execute(params);
 
-      // Assert
       expect(mockOrderRepository.list).toHaveBeenCalledWith(
         expect.objectContaining({ createdAfter, createdBefore }),
       );
     });
 
     it('should return an empty result when no orders match the filters', async () => {
-      // Arrange
       const params: OrderListParams = { page: 1, limit: 10, orderNumber: 'ORD-nonexistent' };
       const emptyResult = buildPaginatedResult([]);
 
       mockOrderRepository.list.mockResolvedValue(emptyResult);
 
-      // Act
       const result = await useCase.execute(params);
 
-      // Assert
       expect(result.data).toHaveLength(0);
       expect(result.meta.total).toBe(0);
     });


### PR DESCRIPTION
## Summary
- implement T8.1 by introducing the Customer aggregate in the domain layer, including repository contract and domain error
- add database migrations to create `customers` and enforce `orders.customer_id` with a safe backfill strategy for existing rows
- update order creation flow, schemas, controller wiring, repository persistence, and tests to require and validate `customerId`

## Why
This enables explicit customer ownership for orders and unlocks the phase-7 customer capabilities while keeping backward migration safety for existing databases.

## Validation
- yarn lint ✅
- yarn build ✅