### PR TITLE
feat(domain): debit stock when order moves to processing

### DIFF
--- a/libs/domain/src/use-cases/orders/update-order-status.usecase.spec.ts
+++ b/libs/domain/src/use-cases/orders/update-order-status.usecase.spec.ts
@@ -1,16 +1,21 @@
 import 'reflect-metadata';
 
 import { UpdateOrderStatusUseCase, UpdateOrderStatusDTO } from './update-order-status.usecase';
+import { IOrderItemRepository } from '../../repositories/order-item.repository';
 import { IOrderRepository } from '../../repositories/order.repository';
+import { IStockRepository } from '../../repositories/stock.repository';
 import { OrderService } from '../../services/order.service';
 import { OrderNotFoundException } from '../../errors/order-not-found.error';
 import { InvalidOrderStatusTransitionError } from '../../errors/invalid-order-status-transition.error';
 import { Order } from '../../entities/order.entity';
+import { OrderItem } from '../../entities/order-item.entity';
 import { OrderStatus } from '../../enums/order-status.enum';
 
 describe('UpdateOrderStatusUseCase', () => {
   let useCase: UpdateOrderStatusUseCase;
   let mockOrderRepository: jest.Mocked<IOrderRepository>;
+  let mockOrderItemRepository: jest.Mocked<IOrderItemRepository>;
+  let mockStockRepository: jest.Mocked<IStockRepository>;
   let mockOrderService: jest.Mocked<OrderService>;
 
   const buildOrder = (overrides: Partial<Order> = {}): Order =>
@@ -25,6 +30,19 @@ describe('UpdateOrderStatusUseCase', () => {
       ...overrides,
     }) as Order;
 
+  const buildOrderItem = (overrides: Partial<OrderItem> = {}): OrderItem =>
+    ({
+      id: 'order-item-1',
+      orderId: 'order-1',
+      productId: 'product-1',
+      quantity: 2,
+      unitPrice: 25,
+      subtotal: 50,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    }) as OrderItem;
+
   beforeEach(() => {
     mockOrderRepository = {
       list: jest.fn(),
@@ -32,6 +50,22 @@ describe('UpdateOrderStatusUseCase', () => {
       createWithItems: jest.fn(),
       updateStatus: jest.fn(),
     } as jest.Mocked<IOrderRepository>;
+
+    mockOrderItemRepository = {
+      findByOrderId: jest.fn(),
+      save: jest.fn(),
+      saveMany: jest.fn(),
+      deleteByOrderId: jest.fn(),
+    } as jest.Mocked<IOrderItemRepository>;
+
+    mockStockRepository = {
+      findAll: jest.fn(),
+      findByProductId: jest.fn(),
+      save: jest.fn(),
+      adjustQuantity: jest.fn(),
+      reserve: jest.fn(),
+      release: jest.fn(),
+    } as jest.Mocked<IStockRepository>;
 
     mockOrderService = {
       generateOrderNumber: jest.fn(),
@@ -41,7 +75,12 @@ describe('UpdateOrderStatusUseCase', () => {
       calculateTotal: jest.fn(),
     } as unknown as jest.Mocked<OrderService>;
 
-    useCase = new UpdateOrderStatusUseCase(mockOrderRepository, mockOrderService);
+    useCase = new UpdateOrderStatusUseCase(
+      mockOrderRepository,
+      mockOrderItemRepository,
+      mockStockRepository,
+      mockOrderService,
+    );
   });
 
   afterEach(() => {
@@ -54,9 +93,15 @@ describe('UpdateOrderStatusUseCase', () => {
       const dto: UpdateOrderStatusDTO = { id: 'order-1', status: OrderStatus.PROCESSING };
       const existingOrder = buildOrder({ status: OrderStatus.PENDING });
       const updatedOrder = buildOrder({ status: OrderStatus.PROCESSING });
+      const orderItems = [
+        buildOrderItem({ productId: 'product-1', quantity: 2 }),
+        buildOrderItem({ id: 'order-item-2', productId: 'product-2', quantity: 3 }),
+      ];
 
       mockOrderService.findOrFail.mockResolvedValue(existingOrder);
       mockOrderService.validateStatusTransition.mockReturnValue(undefined);
+      mockOrderItemRepository.findByOrderId.mockResolvedValue(orderItems);
+      mockStockRepository.adjustQuantity.mockResolvedValue({} as never);
       mockOrderRepository.updateStatus.mockResolvedValue(updatedOrder);
 
       // Act
@@ -72,6 +117,12 @@ describe('UpdateOrderStatusUseCase', () => {
       expect(mockOrderRepository.updateStatus).toHaveBeenCalledWith(
         'order-1',
         OrderStatus.PROCESSING,
+      );
+      expect(mockOrderItemRepository.findByOrderId).toHaveBeenCalledWith('order-1');
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(1, 'product-1', -2);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(2, 'product-2', -3);
+      expect(mockOrderRepository.updateStatus.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mockStockRepository.adjustQuantity.mock.invocationCallOrder[1],
       );
     });
 
@@ -94,6 +145,27 @@ describe('UpdateOrderStatusUseCase', () => {
         OrderStatus.PROCESSING,
         OrderStatus.COMPLETED,
       );
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
+    });
+
+    it('should not debit stock when updating status from PENDING to CANCELLED', async () => {
+      // Arrange
+      const dto: UpdateOrderStatusDTO = { id: 'order-1', status: OrderStatus.CANCELLED };
+      const existingOrder = buildOrder({ status: OrderStatus.PENDING });
+      const updatedOrder = buildOrder({ status: OrderStatus.CANCELLED });
+
+      mockOrderService.findOrFail.mockResolvedValue(existingOrder);
+      mockOrderService.validateStatusTransition.mockReturnValue(undefined);
+      mockOrderRepository.updateStatus.mockResolvedValue(updatedOrder);
+
+      // Act
+      const result = await useCase.execute(dto);
+
+      // Assert
+      expect(result).toEqual(updatedOrder);
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
     });
 
     it('should throw OrderNotFoundException when the order does not exist', async () => {
@@ -104,6 +176,8 @@ describe('UpdateOrderStatusUseCase', () => {
       // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow(OrderNotFoundException);
       expect(mockOrderService.validateStatusTransition).not.toHaveBeenCalled();
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
@@ -119,6 +193,8 @@ describe('UpdateOrderStatusUseCase', () => {
 
       // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow(InvalidOrderStatusTransitionError);
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
@@ -134,6 +210,8 @@ describe('UpdateOrderStatusUseCase', () => {
 
       // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow(InvalidOrderStatusTransitionError);
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
@@ -144,6 +222,62 @@ describe('UpdateOrderStatusUseCase', () => {
 
       // Act & Assert
       await expect(useCase.execute(dto)).rejects.toThrow();
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
+      expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('should rollback debits when updateStatus fails after stock debit', async () => {
+      // Arrange
+      const dto: UpdateOrderStatusDTO = { id: 'order-1', status: OrderStatus.PROCESSING };
+      const existingOrder = buildOrder({ status: OrderStatus.PENDING });
+      const orderItems = [
+        buildOrderItem({ productId: 'product-1', quantity: 2 }),
+        buildOrderItem({ id: 'order-item-2', productId: 'product-2', quantity: 3 }),
+      ];
+      const expectedError = new Error('status update failed');
+
+      mockOrderService.findOrFail.mockResolvedValue(existingOrder);
+      mockOrderService.validateStatusTransition.mockReturnValue(undefined);
+      mockOrderItemRepository.findByOrderId.mockResolvedValue(orderItems);
+      mockStockRepository.adjustQuantity
+        .mockResolvedValueOnce({} as never)
+        .mockResolvedValueOnce({} as never)
+        .mockResolvedValueOnce({} as never)
+        .mockResolvedValueOnce({} as never);
+      mockOrderRepository.updateStatus.mockRejectedValue(expectedError);
+
+      // Act & Assert
+      await expect(useCase.execute(dto)).rejects.toThrow(expectedError);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(1, 'product-1', -2);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(2, 'product-2', -3);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(3, 'product-2', 3);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(4, 'product-1', 2);
+    });
+
+    it('should rollback already-debited items when a later debit fails', async () => {
+      // Arrange
+      const dto: UpdateOrderStatusDTO = { id: 'order-1', status: OrderStatus.PROCESSING };
+      const existingOrder = buildOrder({ status: OrderStatus.PENDING });
+      const orderItems = [
+        buildOrderItem({ productId: 'product-1', quantity: 2 }),
+        buildOrderItem({ id: 'order-item-2', productId: 'product-2', quantity: 3 }),
+      ];
+      const debitError = new Error('debit failed');
+
+      mockOrderService.findOrFail.mockResolvedValue(existingOrder);
+      mockOrderService.validateStatusTransition.mockReturnValue(undefined);
+      mockOrderItemRepository.findByOrderId.mockResolvedValue(orderItems);
+      mockStockRepository.adjustQuantity
+        .mockResolvedValueOnce({} as never)
+        .mockRejectedValueOnce(debitError)
+        .mockResolvedValueOnce({} as never);
+
+      // Act & Assert
+      await expect(useCase.execute(dto)).rejects.toThrow(debitError);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(1, 'product-1', -2);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(2, 'product-2', -3);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(3, 'product-1', 2);
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
   });

--- a/libs/domain/src/use-cases/orders/update-order-status.usecase.ts
+++ b/libs/domain/src/use-cases/orders/update-order-status.usecase.ts
@@ -2,7 +2,9 @@ import { injectable, inject } from 'tsyringe';
 
 import { Order } from '../../entities/order.entity';
 import { OrderStatus } from '../../enums/order-status.enum';
+import { IOrderItemRepository } from '../../repositories/order-item.repository';
 import { IOrderRepository } from '../../repositories/order.repository';
+import { IStockRepository } from '../../repositories/stock.repository';
 import { OrderService } from '../../services/order.service';
 
 /**
@@ -26,6 +28,10 @@ export class UpdateOrderStatusUseCase {
   constructor(
     @inject('IOrderRepository')
     private readonly orderRepository: IOrderRepository,
+    @inject('IOrderItemRepository')
+    private readonly orderItemRepository: IOrderItemRepository,
+    @inject('IStockRepository')
+    private readonly stockRepository: IStockRepository,
     @inject('OrderService')
     private readonly orderService: OrderService,
   ) {}
@@ -43,6 +49,42 @@ export class UpdateOrderStatusUseCase {
 
     this.orderService.validateStatusTransition(order.status, dto.status);
 
+    if (order.status === OrderStatus.PENDING && dto.status === OrderStatus.PROCESSING) {
+      const orderItems = await this.orderItemRepository.findByOrderId(order.id);
+      const debitedItems: Array<{ productId: string; quantity: number }> = [];
+
+      try {
+        for (const item of orderItems) {
+          await this.stockRepository.adjustQuantity(item.productId, -item.quantity);
+          debitedItems.push({ productId: item.productId, quantity: item.quantity });
+        }
+
+        const updatedOrder = await this.orderRepository.updateStatus(dto.id, dto.status);
+
+        return updatedOrder;
+      } catch (error) {
+        await this.rollbackDebits(debitedItems);
+        throw error;
+      }
+    }
+
     return this.orderRepository.updateStatus(dto.id, dto.status);
+  }
+
+  /**
+   * Best-effort compensation to revert previously debited stock.
+   */
+  private async rollbackDebits(
+    debitedItems: Array<{ productId: string; quantity: number }>,
+  ): Promise<void> {
+    for (let index = debitedItems.length - 1; index >= 0; index -= 1) {
+      const item = debitedItems[index];
+
+      try {
+        await this.stockRepository.adjustQuantity(item.productId, item.quantity);
+      } catch {
+        // Intentionally ignored to preserve the original failure.
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement T8.6 by adding stock debit side-effects in `UpdateOrderStatusUseCase` for the `PENDING -> PROCESSING` transition
- keep non-target transitions (`PENDING -> CANCELLED`, `PROCESSING -> COMPLETED`) unchanged with no stock debit
- expand unit coverage to verify side-effects, call ordering, and rollback behavior on intermediate failures

## Why
This enforces the domain rule that stock must be decremented when an order begins processing, preventing inventory drift during lifecycle transitions.

## Validation
- yarn nx test domain --testPathPattern=libs/domain/src/use-cases/orders/update-order-status.usecase.spec.ts ✅
- yarn lint ✅