### PR TITLE
feat(domain): refund stock when cancelling processing orders

### DIFF
--- a/libs/domain/src/use-cases/orders/cancel-order.usecase.spec.ts
+++ b/libs/domain/src/use-cases/orders/cancel-order.usecase.spec.ts
@@ -1,16 +1,21 @@
 import 'reflect-metadata';
 
 import { CancelOrderUseCase } from './cancel-order.usecase';
+import { IOrderItemRepository } from '../../repositories/order-item.repository';
 import { IOrderRepository } from '../../repositories/order.repository';
+import { IStockRepository } from '../../repositories/stock.repository';
 import { OrderService } from '../../services/order.service';
 import { OrderNotFoundException } from '../../errors/order-not-found.error';
 import { InvalidOrderStatusTransitionError } from '../../errors/invalid-order-status-transition.error';
 import { Order } from '../../entities/order.entity';
+import { OrderItem } from '../../entities/order-item.entity';
 import { OrderStatus } from '../../enums/order-status.enum';
 
 describe('CancelOrderUseCase', () => {
   let useCase: CancelOrderUseCase;
   let mockOrderRepository: jest.Mocked<IOrderRepository>;
+  let mockOrderItemRepository: jest.Mocked<IOrderItemRepository>;
+  let mockStockRepository: jest.Mocked<IStockRepository>;
   let mockOrderService: jest.Mocked<OrderService>;
 
   const buildOrder = (overrides: Partial<Order> = {}): Order =>
@@ -26,6 +31,19 @@ describe('CancelOrderUseCase', () => {
       ...overrides,
     }) as Order;
 
+  const buildOrderItem = (overrides: Partial<OrderItem> = {}): OrderItem =>
+    ({
+      id: 'order-item-1',
+      orderId: 'order-1',
+      productId: 'product-1',
+      quantity: 2,
+      unitPrice: 25,
+      subtotal: 50,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    }) as OrderItem;
+
   beforeEach(() => {
     mockOrderRepository = {
       list: jest.fn(),
@@ -33,6 +51,22 @@ describe('CancelOrderUseCase', () => {
       createWithItems: jest.fn(),
       updateStatus: jest.fn(),
     } as jest.Mocked<IOrderRepository>;
+
+    mockOrderItemRepository = {
+      findByOrderId: jest.fn(),
+      save: jest.fn(),
+      saveMany: jest.fn(),
+      deleteByOrderId: jest.fn(),
+    } as jest.Mocked<IOrderItemRepository>;
+
+    mockStockRepository = {
+      findAll: jest.fn(),
+      findByProductId: jest.fn(),
+      save: jest.fn(),
+      adjustQuantity: jest.fn(),
+      reserve: jest.fn(),
+      release: jest.fn(),
+    } as jest.Mocked<IStockRepository>;
 
     mockOrderService = {
       generateOrderNumber: jest.fn(),
@@ -42,7 +76,12 @@ describe('CancelOrderUseCase', () => {
       calculateTotal: jest.fn(),
     } as unknown as jest.Mocked<OrderService>;
 
-    useCase = new CancelOrderUseCase(mockOrderRepository, mockOrderService);
+    useCase = new CancelOrderUseCase(
+      mockOrderRepository,
+      mockOrderItemRepository,
+      mockStockRepository,
+      mockOrderService,
+    );
   });
 
   afterEach(() => {
@@ -50,7 +89,7 @@ describe('CancelOrderUseCase', () => {
   });
 
   describe('execute', () => {
-    it('should cancel a PENDING order successfully', async () => {
+    it('should cancel a PENDING order successfully without refunding stock', async () => {
       const pendingOrder = buildOrder({ status: OrderStatus.PENDING });
       const cancelledOrder = buildOrder({ status: OrderStatus.CANCELLED });
 
@@ -70,14 +109,22 @@ describe('CancelOrderUseCase', () => {
         'order-1',
         OrderStatus.CANCELLED,
       );
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
     });
 
-    it('should cancel a PROCESSING order successfully', async () => {
+    it('should refund stock items before cancelling a PROCESSING order', async () => {
       const processingOrder = buildOrder({ status: OrderStatus.PROCESSING });
       const cancelledOrder = buildOrder({ status: OrderStatus.CANCELLED });
+      const orderItems = [
+        buildOrderItem({ productId: 'product-1', quantity: 2 }),
+        buildOrderItem({ id: 'order-item-2', productId: 'product-2', quantity: 3 }),
+      ];
 
       mockOrderService.findOrFail.mockResolvedValue(processingOrder);
       mockOrderService.validateStatusTransition.mockReturnValue(undefined);
+      mockOrderItemRepository.findByOrderId.mockResolvedValue(orderItems);
+      mockStockRepository.adjustQuantity.mockResolvedValue({} as never);
       mockOrderRepository.updateStatus.mockResolvedValue(cancelledOrder);
 
       const result = await useCase.execute('order-1');
@@ -91,6 +138,12 @@ describe('CancelOrderUseCase', () => {
         'order-1',
         OrderStatus.CANCELLED,
       );
+      expect(mockOrderItemRepository.findByOrderId).toHaveBeenCalledWith('order-1');
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(1, 'product-1', 2);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenNthCalledWith(2, 'product-2', 3);
+      expect(mockOrderRepository.updateStatus.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mockStockRepository.adjustQuantity.mock.invocationCallOrder[1],
+      );
     });
 
     it('should throw OrderNotFoundException when the order does not exist', async () => {
@@ -98,6 +151,8 @@ describe('CancelOrderUseCase', () => {
 
       await expect(useCase.execute('non-existent')).rejects.toThrow(OrderNotFoundException);
       expect(mockOrderService.validateStatusTransition).not.toHaveBeenCalled();
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
@@ -110,6 +165,8 @@ describe('CancelOrderUseCase', () => {
       });
 
       await expect(useCase.execute('order-1')).rejects.toThrow(InvalidOrderStatusTransitionError);
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 
@@ -122,6 +179,23 @@ describe('CancelOrderUseCase', () => {
       });
 
       await expect(useCase.execute('order-1')).rejects.toThrow(InvalidOrderStatusTransitionError);
+      expect(mockOrderItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(mockStockRepository.adjustQuantity).not.toHaveBeenCalled();
+      expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('should not update status when stock refund fails for a PROCESSING order', async () => {
+      const processingOrder = buildOrder({ status: OrderStatus.PROCESSING });
+      const orderItems = [buildOrderItem({ productId: 'product-1', quantity: 2 })];
+      const expectedError = new Error('refund failed');
+
+      mockOrderService.findOrFail.mockResolvedValue(processingOrder);
+      mockOrderService.validateStatusTransition.mockReturnValue(undefined);
+      mockOrderItemRepository.findByOrderId.mockResolvedValue(orderItems);
+      mockStockRepository.adjustQuantity.mockRejectedValue(expectedError);
+
+      await expect(useCase.execute('order-1')).rejects.toThrow(expectedError);
+      expect(mockStockRepository.adjustQuantity).toHaveBeenCalledWith('product-1', 2);
       expect(mockOrderRepository.updateStatus).not.toHaveBeenCalled();
     });
 

--- a/libs/domain/src/use-cases/orders/cancel-order.usecase.ts
+++ b/libs/domain/src/use-cases/orders/cancel-order.usecase.ts
@@ -2,7 +2,9 @@ import { injectable, inject } from 'tsyringe';
 
 import { Order } from '../../entities/order.entity';
 import { OrderStatus } from '../../enums/order-status.enum';
+import { IOrderItemRepository } from '../../repositories/order-item.repository';
 import { IOrderRepository } from '../../repositories/order.repository';
+import { IStockRepository } from '../../repositories/stock.repository';
 import { OrderService } from '../../services/order.service';
 
 /**
@@ -17,6 +19,10 @@ export class CancelOrderUseCase {
   constructor(
     @inject('IOrderRepository')
     private readonly orderRepository: IOrderRepository,
+    @inject('IOrderItemRepository')
+    private readonly orderItemRepository: IOrderItemRepository,
+    @inject('IStockRepository')
+    private readonly stockRepository: IStockRepository,
     @inject('OrderService')
     private readonly orderService: OrderService,
   ) {}
@@ -33,6 +39,14 @@ export class CancelOrderUseCase {
     const order = await this.orderService.findOrFail(id);
 
     this.orderService.validateStatusTransition(order.status, OrderStatus.CANCELLED);
+
+    if (order.status === OrderStatus.PROCESSING) {
+      const orderItems = await this.orderItemRepository.findByOrderId(order.id);
+
+      for (const item of orderItems) {
+        await this.stockRepository.adjustQuantity(item.productId, item.quantity);
+      }
+    }
 
     return this.orderRepository.updateStatus(id, OrderStatus.CANCELLED);
   }


### PR DESCRIPTION
## Summary
- implement T8.7 by refunding stock on `PROCESSING -> CANCELLED` in `CancelOrderUseCase`
- keep `PENDING -> CANCELLED` without stock refund side-effect
- extend unit tests for refund behavior, ordering, and failure paths

## Why
This keeps inventory consistent across order lifecycle transitions by undoing prior stock debits when a processing order is cancelled.

## Validation
- targeted cancel-order use case spec ✅
- yarn lint ✅