### PR TITLE
feat(domain): add customer service and use cases

### DIFF
--- a/apps/api/src/container/dependency-injection.ts
+++ b/apps/api/src/container/dependency-injection.ts
@@ -13,6 +13,7 @@ import {
   ProductService,
   StockService,
   OrderService,
+  CustomerService,
   CreateCategoryUseCase,
   ListCategoriesUseCase,
   GetCategoryUseCase,
@@ -30,6 +31,8 @@ import {
   ListOrdersUseCase,
   UpdateOrderStatusUseCase,
   CancelOrderUseCase,
+  CreateCustomerUseCase,
+  GetCustomerUseCase,
 } from '@domain/index';
 
 /**
@@ -69,6 +72,7 @@ export function registerDependencies(): void {
   container.registerSingleton<ProductService>('ProductService', ProductService);
   container.registerSingleton<StockService>('StockService', StockService);
   container.registerSingleton<OrderService>('OrderService', OrderService);
+  container.registerSingleton<CustomerService>('CustomerService', CustomerService);
 
   container.registerSingleton<CreateCategoryUseCase>(
     'CreateCategoryUseCase',
@@ -105,4 +109,10 @@ export function registerDependencies(): void {
     UpdateOrderStatusUseCase,
   );
   container.registerSingleton<CancelOrderUseCase>('CancelOrderUseCase', CancelOrderUseCase);
+
+  container.registerSingleton<CreateCustomerUseCase>(
+    'CreateCustomerUseCase',
+    CreateCustomerUseCase,
+  );
+  container.registerSingleton<GetCustomerUseCase>('GetCustomerUseCase', GetCustomerUseCase);
 }

--- a/apps/api/src/plugins/error-handler.plugin.spec.ts
+++ b/apps/api/src/plugins/error-handler.plugin.spec.ts
@@ -8,6 +8,7 @@ import {
   OrderNotFoundException,
   InvalidOrderStatusTransitionError,
   CustomerNotFoundException,
+  CustomerAlreadyExistsException,
 } from '@domain/index';
 import { OrderStatus } from '@domain/enums/order-status.enum';
 
@@ -98,6 +99,19 @@ describe('registerErrorHandler', () => {
       expect(body).toEqual({
         error: 'CustomerNotFoundException',
         message: 'Cliente não encontrado',
+      });
+    });
+
+    it('maps CustomerAlreadyExistsException to 409 with correct envelope', async () => {
+      const app = await buildApp(() => new CustomerAlreadyExistsException());
+
+      const response = await app.inject({ method: 'GET', url: '/test' });
+
+      expect(response.statusCode).toBe(409);
+      const body = JSON.parse(response.body);
+      expect(body).toEqual({
+        error: 'CustomerAlreadyExistsException',
+        message: 'Cliente já cadastrado',
       });
     });
 

--- a/apps/api/src/plugins/error-handler.plugin.ts
+++ b/apps/api/src/plugins/error-handler.plugin.ts
@@ -9,6 +9,7 @@ import {
   OrderNotFoundException,
   InvalidOrderStatusTransitionError,
   CustomerNotFoundException,
+  CustomerAlreadyExistsException,
 } from '@domain/index';
 
 /**
@@ -67,6 +68,10 @@ const errorMap = new Map<new (...args: never[]) => DomainError, ErrorMapEntry>([
   [
     CustomerNotFoundException,
     { status: 404, error: 'CustomerNotFoundException', message: 'Cliente não encontrado' },
+  ],
+  [
+    CustomerAlreadyExistsException,
+    { status: 409, error: 'CustomerAlreadyExistsException', message: 'Cliente já cadastrado' },
   ],
 ]);
 

--- a/apps/api/src/repositories/customer.repository.impl.ts
+++ b/apps/api/src/repositories/customer.repository.impl.ts
@@ -1,6 +1,7 @@
 import { injectable } from 'tsyringe';
 import { DataSource, IsNull, Repository } from 'typeorm';
 
+import { CustomerAlreadyExistsException } from '@domain/errors/customer-already-exists.error';
 import { Customer } from '@domain/entities/customer.entity';
 import { ICustomerRepository } from '@domain/repositories/customer.repository';
 
@@ -35,7 +36,20 @@ export class CustomerRepositoryImpl implements ICustomerRepository {
   }
 
   async save(customer: Customer): Promise<Customer> {
-    return this.repository.save(customer);
+    try {
+      return await this.repository.save(customer);
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code?: string }).code === '23505'
+      ) {
+        throw new CustomerAlreadyExistsException();
+      }
+
+      throw error;
+    }
   }
 
   async softDelete(id: string): Promise<void> {

--- a/libs/domain/src/entities/customer.entity.ts
+++ b/libs/domain/src/entities/customer.entity.ts
@@ -17,7 +17,7 @@ export class Customer extends BaseEntity {
   /**
    * Unique email address of the customer.
    */
-  @Column({ type: 'varchar', length: 255, name: 'email' })
+  @Column({ type: 'varchar', length: 255, name: 'email', unique: true })
   email!: string;
 
   /**

--- a/libs/domain/src/errors/customer-already-exists.error.ts
+++ b/libs/domain/src/errors/customer-already-exists.error.ts
@@ -1,0 +1,10 @@
+import { DomainError } from './domain.error';
+
+/**
+ * Thrown when trying to create a customer with an email already in use.
+ */
+export class CustomerAlreadyExistsException extends DomainError {
+  constructor() {
+    super('Cliente já cadastrado');
+  }
+}

--- a/libs/domain/src/index.ts
+++ b/libs/domain/src/index.ts
@@ -15,6 +15,7 @@ export { InsufficientStockError } from './errors/insufficient-stock.error';
 export { OrderNotFoundException } from './errors/order-not-found.error';
 export { InvalidOrderStatusTransitionError } from './errors/invalid-order-status-transition.error';
 export { CustomerNotFoundException } from './errors/customer-not-found.error';
+export { CustomerAlreadyExistsException } from './errors/customer-already-exists.error';
 
 export type { ICategoryRepository, CategoryListParams } from './repositories/category.repository';
 export type { IProductRepository, ProductListParams } from './repositories/product.repository';
@@ -29,6 +30,8 @@ export { ProductService } from './services/product.service';
 export { StockService } from './services/stock.service';
 export { OrderService } from './services/order.service';
 export type { CreateOrderItemDTO, OrderItemData } from './services/order.service';
+export { CustomerService } from './services/customer.service';
+export type { CreateCustomerDTO } from './services/customer.service';
 
 export { CreateCategoryUseCase } from './use-cases/category/create-category.usecase';
 export { ListCategoriesUseCase } from './use-cases/category/list-categories.usecase';
@@ -57,3 +60,6 @@ export { ListOrdersUseCase } from './use-cases/orders/list-orders.usecase';
 export { UpdateOrderStatusUseCase } from './use-cases/orders/update-order-status.usecase';
 export type { UpdateOrderStatusDTO } from './use-cases/orders/update-order-status.usecase';
 export { CancelOrderUseCase } from './use-cases/orders/cancel-order.usecase';
+
+export { CreateCustomerUseCase } from './use-cases/customer/create-customer.usecase';
+export { GetCustomerUseCase } from './use-cases/customer/get-customer.usecase';

--- a/libs/domain/src/services/customer.service.spec.ts
+++ b/libs/domain/src/services/customer.service.spec.ts
@@ -1,0 +1,80 @@
+import 'reflect-metadata';
+
+import { Customer } from '../entities/customer.entity';
+import { CustomerNotFoundException } from '../errors/customer-not-found.error';
+import { ICustomerRepository } from '../repositories/customer.repository';
+import { CreateCustomerDTO, CustomerService } from './customer.service';
+
+describe('CustomerService', () => {
+  let service: CustomerService;
+  let mockCustomerRepository: jest.Mocked<ICustomerRepository>;
+
+  const makeCustomer = (overrides: Partial<Customer> = {}): Customer => {
+    const customer = new Customer();
+    customer.id = 'customer-1';
+    customer.name = 'Maria Silva';
+    customer.email = 'maria@cornershop.com';
+    customer.phone = '11999999999';
+    Object.assign(customer, overrides);
+    return customer;
+  };
+
+  beforeEach(() => {
+    mockCustomerRepository = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+      softDelete: jest.fn(),
+    };
+
+    service = new CustomerService(mockCustomerRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('buildCustomer', () => {
+    it('should build a customer with provided fields', () => {
+      // Arrange
+      const dto: CreateCustomerDTO = {
+        name: 'João Santos',
+        email: 'joao@cornershop.com',
+        phone: '11988887777',
+      };
+
+      // Act
+      const result = service.buildCustomer(dto);
+
+      // Assert
+      expect(result).toBeInstanceOf(Customer);
+      expect(result.name).toBe(dto.name);
+      expect(result.email).toBe(dto.email);
+      expect(result.phone).toBe(dto.phone);
+    });
+  });
+
+  describe('findOrFail', () => {
+    it('should return customer when found', async () => {
+      // Arrange
+      const customer = makeCustomer();
+      mockCustomerRepository.findById.mockResolvedValue(customer);
+
+      // Act
+      const result = await service.findOrFail('customer-1');
+
+      // Assert
+      expect(result).toBe(customer);
+      expect(mockCustomerRepository.findById).toHaveBeenCalledWith('customer-1');
+    });
+
+    it('should throw CustomerNotFoundException when customer is not found', async () => {
+      // Arrange
+      mockCustomerRepository.findById.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findOrFail('missing-id')).rejects.toThrow(CustomerNotFoundException);
+      expect(mockCustomerRepository.findById).toHaveBeenCalledWith('missing-id');
+    });
+  });
+});

--- a/libs/domain/src/services/customer.service.ts
+++ b/libs/domain/src/services/customer.service.ts
@@ -1,0 +1,52 @@
+import { injectable, inject } from 'tsyringe';
+
+import { Customer } from '../entities/customer.entity';
+import { CustomerNotFoundException } from '../errors/customer-not-found.error';
+import { ICustomerRepository } from '../repositories/customer.repository';
+
+/**
+ * DTO for creating a new customer.
+ */
+export interface CreateCustomerDTO {
+  /** Full name of the customer. */
+  name: string;
+  /** Unique e-mail address. */
+  email: string;
+  /** Contact phone number. */
+  phone: string;
+}
+
+/**
+ * Service containing reusable business logic for Customer operations.
+ */
+@injectable()
+export class CustomerService {
+  constructor(
+    @inject('ICustomerRepository')
+    private readonly customerRepository: ICustomerRepository,
+  ) {}
+
+  /**
+   * Builds a new Customer entity from the supplied DTO.
+   */
+  buildCustomer(dto: CreateCustomerDTO): Customer {
+    const customer = new Customer();
+    customer.name = dto.name;
+    customer.email = dto.email;
+    customer.phone = dto.phone;
+    return customer;
+  }
+
+  /**
+   * Retrieves a customer by id and throws when it does not exist.
+   */
+  async findOrFail(id: string): Promise<Customer> {
+    const customer = await this.customerRepository.findById(id);
+
+    if (!customer) {
+      throw new CustomerNotFoundException();
+    }
+
+    return customer;
+  }
+}

--- a/libs/domain/src/use-cases/customer/create-customer.usecase.spec.ts
+++ b/libs/domain/src/use-cases/customer/create-customer.usecase.spec.ts
@@ -1,0 +1,126 @@
+import 'reflect-metadata';
+
+import { Customer } from '../../entities/customer.entity';
+import { CustomerAlreadyExistsException } from '../../errors/customer-already-exists.error';
+import { ICustomerRepository } from '../../repositories/customer.repository';
+import { CreateCustomerDTO, CustomerService } from '../../services/customer.service';
+import { CreateCustomerUseCase } from './create-customer.usecase';
+
+describe('CreateCustomerUseCase', () => {
+  let useCase: CreateCustomerUseCase;
+  let mockCustomerRepository: jest.Mocked<ICustomerRepository>;
+  let mockCustomerService: jest.Mocked<CustomerService>;
+
+  const makeCustomer = (overrides: Partial<Customer> = {}): Customer => {
+    const customer = new Customer();
+    customer.id = 'customer-1';
+    customer.name = 'Maria Silva';
+    customer.email = 'maria@cornershop.com';
+    customer.phone = '11999999999';
+    Object.assign(customer, overrides);
+    return customer;
+  };
+
+  beforeEach(() => {
+    mockCustomerRepository = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      save: jest.fn(),
+      softDelete: jest.fn(),
+    };
+
+    mockCustomerService = {
+      buildCustomer: jest.fn(),
+      findOrFail: jest.fn(),
+    } as unknown as jest.Mocked<CustomerService>;
+
+    useCase = new CreateCustomerUseCase(mockCustomerRepository, mockCustomerService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execute', () => {
+    it('should create and return customer when email is unique', async () => {
+      // Arrange
+      const dto: CreateCustomerDTO = {
+        name: 'Maria Silva',
+        email: 'maria@cornershop.com',
+        phone: '11999999999',
+      };
+      const builtCustomer = makeCustomer();
+      const savedCustomer = makeCustomer();
+
+      mockCustomerRepository.findByEmail.mockResolvedValue(null);
+      mockCustomerService.buildCustomer.mockReturnValue(builtCustomer);
+      mockCustomerRepository.save.mockResolvedValue(savedCustomer);
+
+      // Act
+      const result = await useCase.execute(dto);
+
+      // Assert
+      expect(result).toBe(savedCustomer);
+      expect(mockCustomerRepository.findByEmail).toHaveBeenCalledWith(dto.email);
+      expect(mockCustomerService.buildCustomer).toHaveBeenCalledWith(dto);
+      expect(mockCustomerRepository.save).toHaveBeenCalledWith(builtCustomer);
+    });
+
+    it('should normalize email before checking uniqueness and saving', async () => {
+      // Arrange
+      const dto: CreateCustomerDTO = {
+        name: 'Maria Silva',
+        email: '  Maria.Silva@CornerShop.com  ',
+        phone: '11999999999',
+      };
+      const builtCustomer = makeCustomer({ email: 'maria.silva@cornershop.com' });
+
+      mockCustomerRepository.findByEmail.mockResolvedValue(null);
+      mockCustomerService.buildCustomer.mockReturnValue(builtCustomer);
+      mockCustomerRepository.save.mockResolvedValue(builtCustomer);
+
+      // Act
+      await useCase.execute(dto);
+
+      // Assert
+      expect(mockCustomerRepository.findByEmail).toHaveBeenCalledWith('maria.silva@cornershop.com');
+      expect(mockCustomerService.buildCustomer).toHaveBeenCalledWith({
+        ...dto,
+        email: 'maria.silva@cornershop.com',
+      });
+    });
+
+    it('should throw CustomerAlreadyExistsException when email already exists', async () => {
+      // Arrange
+      const dto: CreateCustomerDTO = {
+        name: 'Maria Silva',
+        email: 'maria@cornershop.com',
+        phone: '11999999999',
+      };
+      mockCustomerRepository.findByEmail.mockResolvedValue(makeCustomer());
+
+      // Act & Assert
+      await expect(useCase.execute(dto)).rejects.toThrow(CustomerAlreadyExistsException);
+      expect(mockCustomerService.buildCustomer).not.toHaveBeenCalled();
+      expect(mockCustomerRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should propagate repository save errors', async () => {
+      // Arrange
+      const dto: CreateCustomerDTO = {
+        name: 'Maria Silva',
+        email: 'maria@cornershop.com',
+        phone: '11999999999',
+      };
+      const builtCustomer = makeCustomer();
+      const expectedError = new Error('DB write failed');
+
+      mockCustomerRepository.findByEmail.mockResolvedValue(null);
+      mockCustomerService.buildCustomer.mockReturnValue(builtCustomer);
+      mockCustomerRepository.save.mockRejectedValue(expectedError);
+
+      // Act & Assert
+      await expect(useCase.execute(dto)).rejects.toThrow('DB write failed');
+    });
+  });
+});

--- a/libs/domain/src/use-cases/customer/create-customer.usecase.ts
+++ b/libs/domain/src/use-cases/customer/create-customer.usecase.ts
@@ -1,0 +1,39 @@
+import { injectable, inject } from 'tsyringe';
+
+import { Customer } from '../../entities/customer.entity';
+import { CustomerAlreadyExistsException } from '../../errors/customer-already-exists.error';
+import { ICustomerRepository } from '../../repositories/customer.repository';
+import { CreateCustomerDTO, CustomerService } from '../../services/customer.service';
+
+/**
+ * Use case responsible for creating a new customer.
+ */
+@injectable()
+export class CreateCustomerUseCase {
+  constructor(
+    @inject('ICustomerRepository')
+    private readonly customerRepository: ICustomerRepository,
+    @inject('CustomerService')
+    private readonly customerService: CustomerService,
+  ) {}
+
+  /**
+   * Creates a customer after enforcing unique email.
+   */
+  async execute(dto: CreateCustomerDTO): Promise<Customer> {
+    const normalizedEmail = dto.email.trim().toLowerCase();
+    const normalizedDto: CreateCustomerDTO = {
+      ...dto,
+      email: normalizedEmail,
+    };
+
+    const existing = await this.customerRepository.findByEmail(normalizedEmail);
+
+    if (existing) {
+      throw new CustomerAlreadyExistsException();
+    }
+
+    const customer = this.customerService.buildCustomer(normalizedDto);
+    return this.customerRepository.save(customer);
+  }
+}

--- a/libs/domain/src/use-cases/customer/get-customer.usecase.spec.ts
+++ b/libs/domain/src/use-cases/customer/get-customer.usecase.spec.ts
@@ -1,0 +1,58 @@
+import 'reflect-metadata';
+
+import { Customer } from '../../entities/customer.entity';
+import { CustomerNotFoundException } from '../../errors/customer-not-found.error';
+import { CustomerService } from '../../services/customer.service';
+import { GetCustomerUseCase } from './get-customer.usecase';
+
+describe('GetCustomerUseCase', () => {
+  let useCase: GetCustomerUseCase;
+  let mockCustomerService: jest.Mocked<CustomerService>;
+
+  const makeCustomer = (overrides: Partial<Customer> = {}): Customer => {
+    const customer = new Customer();
+    customer.id = 'customer-1';
+    customer.name = 'Maria Silva';
+    customer.email = 'maria@cornershop.com';
+    customer.phone = '11999999999';
+    Object.assign(customer, overrides);
+    return customer;
+  };
+
+  beforeEach(() => {
+    mockCustomerService = {
+      buildCustomer: jest.fn(),
+      findOrFail: jest.fn(),
+    } as unknown as jest.Mocked<CustomerService>;
+
+    useCase = new GetCustomerUseCase(mockCustomerService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('execute', () => {
+    it('should return customer when found', async () => {
+      // Arrange
+      const customer = makeCustomer();
+      mockCustomerService.findOrFail.mockResolvedValue(customer);
+
+      // Act
+      const result = await useCase.execute('customer-1');
+
+      // Assert
+      expect(result).toBe(customer);
+      expect(mockCustomerService.findOrFail).toHaveBeenCalledWith('customer-1');
+    });
+
+    it('should throw CustomerNotFoundException when customer does not exist', async () => {
+      // Arrange
+      mockCustomerService.findOrFail.mockRejectedValue(new CustomerNotFoundException());
+
+      // Act & Assert
+      await expect(useCase.execute('missing-id')).rejects.toThrow(CustomerNotFoundException);
+      expect(mockCustomerService.findOrFail).toHaveBeenCalledWith('missing-id');
+    });
+  });
+});

--- a/libs/domain/src/use-cases/customer/get-customer.usecase.ts
+++ b/libs/domain/src/use-cases/customer/get-customer.usecase.ts
@@ -1,0 +1,22 @@
+import { injectable, inject } from 'tsyringe';
+
+import { Customer } from '../../entities/customer.entity';
+import { CustomerService } from '../../services/customer.service';
+
+/**
+ * Use case responsible for retrieving a customer by id.
+ */
+@injectable()
+export class GetCustomerUseCase {
+  constructor(
+    @inject('CustomerService')
+    private readonly customerService: CustomerService,
+  ) {}
+
+  /**
+   * Returns a customer or throws when it does not exist.
+   */
+  async execute(id: string): Promise<Customer> {
+    return this.customerService.findOrFail(id);
+  }
+}


### PR DESCRIPTION
## Summary
- implement T8.2 by adding `CustomerService`, `CreateCustomerUseCase`, and `GetCustomerUseCase` in the domain layer
- add unit coverage for customer service and use cases, plus error mapping for duplicate customer creation
- wire customer service/use cases in DI and export new domain symbols

## Why
This unlocks customer application flows required by Fase 7 and provides domain-level orchestration before HTTP controller work.

## Validation
- targeted domain tests for customer service/usecases ✅
- yarn lint ✅
- yarn build ✅