### PR TITLE
fix(api): align order creation error schemas with customer validation

### DIFF
--- a/apps/api/src/http/routes/order.routes.ts
+++ b/apps/api/src/http/routes/order.routes.ts
@@ -31,8 +31,12 @@ export async function registerOrderRoutes(app: FastifyInstance): Promise<void> {
       body: { $ref: 'OrdersCreateBody#' },
       response: {
         201: { $ref: 'OrdersCreateResponse#' },
-        400: { $ref: 'InsufficientStockResponse#' },
-        404: { $ref: 'ProductNotFoundResponse#' },
+        400: {
+          oneOf: [{ $ref: 'ValidationErrorResponse#' }, { $ref: 'InsufficientStockResponse#' }],
+        },
+        404: {
+          oneOf: [{ $ref: 'ProductNotFoundResponse#' }, { $ref: 'CustomerNotFoundResponse#' }],
+        },
         500: { $ref: 'InternalServerErrorResponse#' },
       },
     },

--- a/apps/api/src/http/schemas/index.ts
+++ b/apps/api/src/http/schemas/index.ts
@@ -16,6 +16,7 @@ export type {
 } from './categories.schema';
 
 export {
+  customerNotFoundResponseSchema,
   createOrderBodySchema,
   createOrderResponseSchema,
   getOrderResponseSchema,
@@ -30,6 +31,7 @@ export {
   updateOrderStatusBodySchema,
 } from './orders.schema';
 export type {
+  CustomerNotFoundResponseSchema,
   CreateOrderBodySchema,
   CreateOrderResponseSchema,
   GetOrderResponseSchema,

--- a/apps/api/src/http/schemas/orders.schema.ts
+++ b/apps/api/src/http/schemas/orders.schema.ts
@@ -135,13 +135,20 @@ export const orderNotFoundResponseSchema = domainErrorResponseSchema.extend({
 
 export type OrderNotFoundResponseSchema = z.infer<typeof orderNotFoundResponseSchema>;
 
+export const customerNotFoundResponseSchema = domainErrorResponseSchema.extend({
+  error: z.literal('CustomerNotFoundException'),
+  message: z.literal('Cliente não encontrado'),
+});
+
+export type CustomerNotFoundResponseSchema = z.infer<typeof customerNotFoundResponseSchema>;
+
 export const insufficientStockResponseSchema = domainErrorResponseSchema.extend({
   error: z.literal('InsufficientStockError'),
   message: z.literal('Estoque insuficiente'),
 });
 
 export const insufficientStockDetailedResponseSchema = z.object({
-  error: z.string(),
+  error: z.literal('InsufficientStockError'),
   available: z.number().int().nonnegative(),
   requested: z.number().int().positive(),
 });

--- a/apps/api/src/plugins/http-schemas.plugin.spec.ts
+++ b/apps/api/src/plugins/http-schemas.plugin.spec.ts
@@ -26,6 +26,7 @@ describe('registerHttpSchemas', () => {
     expect(schemas).toHaveProperty('OrderResponse');
     expect(schemas).toHaveProperty('OrderStatusResponse');
     expect(schemas).toHaveProperty('OrdersListResponse');
+    expect(schemas).toHaveProperty('CustomerNotFoundResponse');
 
     expect(schemas).toHaveProperty('ValidationErrorResponse');
     expect(schemas).toHaveProperty('InternalServerErrorResponse');

--- a/apps/api/src/plugins/http-schemas.plugin.ts
+++ b/apps/api/src/plugins/http-schemas.plugin.ts
@@ -3,6 +3,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import {
   categoryNotFoundResponseSchema,
+  customerNotFoundResponseSchema,
   categoryParamsSchema,
   createOrderBodySchema,
   createOrderResponseSchema,
@@ -56,6 +57,7 @@ const SCHEMA_REGISTRY: RegisteredZodSchema[] = [
   { id: 'OrderStatusResponse', schema: getOrderStatusResponseSchema },
   { id: 'OrdersListResponse', schema: listOrdersResponseSchema },
   { id: 'OrderNotFoundResponse', schema: orderNotFoundResponseSchema },
+  { id: 'CustomerNotFoundResponse', schema: customerNotFoundResponseSchema },
   { id: 'InsufficientStockResponse', schema: insufficientStockResponseSchema },
   { id: 'InsufficientStockDetailedResponse', schema: insufficientStockDetailedResponseSchema },
 


### PR DESCRIPTION
## Summary
- Aligns  OpenAPI error responses with actual behavior ( validation/stock,  product/customer).
- Registers and exports  schema for Orders flow.
- Hardens insufficient stock detailed error schema to  literal.

## Validation
- yarn run v1.22.22
$ /home/vwnunes/Projetos/common-cornershop-T8.5/node_modules/.bin/jest --config apps/api/jest.config.ts apps/api/src/http/schemas/__tests__/schemas.spec.ts apps/api/src/plugins/http-schemas.plugin.spec.ts apps/api/src/http/controllers/order.controller.integration.spec.ts apps/api/src/http/controllers/order.controller.spec.ts libs/domain/src/use-cases/orders/create-order.usecase.spec.ts --runInBand
Done in 2.04s.
- 

## Roadmap
- Implements T8.5 completion refinements for the customerId/order contract.