### PR TITLE
feat(api): add customer routes controller and schema registry

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { registerOrderRoutes } from './http/routes/order.routes';
 import { registerDependencies } from './container/dependency-injection';
 import { registerProductRoutes } from './routes/product.routes';
 import { registerCategoryRoutes } from './routes/category.routes';
+import { registerCustomerRoutes } from './routes/customer.routes';
 import { registerErrorHandler } from './plugins/error-handler.plugin';
 import { registerHttpSchemas } from './plugins/http-schemas.plugin';
 import { registerSwagger } from './plugins/swagger.plugin';
@@ -42,6 +43,7 @@ export async function createApp(): Promise<FastifyInstance> {
   await registerHttpSchemas(app);
   await registerProductRoutes(app);
   await registerCategoryRoutes(app);
+  await registerCustomerRoutes(app);
   await registerOrderRoutes(app);
 
   return app;

--- a/apps/api/src/controllers/customer.controller.integration.spec.ts
+++ b/apps/api/src/controllers/customer.controller.integration.spec.ts
@@ -1,0 +1,156 @@
+import 'reflect-metadata';
+
+import Fastify, { FastifyInstance } from 'fastify';
+
+import { CustomerAlreadyExistsException, CustomerNotFoundException } from '@domain/index';
+
+import { registerErrorHandler } from '../plugins/error-handler.plugin';
+
+import { CustomerController } from './customer.controller';
+
+describe('CustomerController (integration)', () => {
+  let app: FastifyInstance;
+  let createCustomerUseCase: { execute: jest.Mock };
+  let getCustomerUseCase: { execute: jest.Mock };
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    registerErrorHandler(app);
+
+    createCustomerUseCase = { execute: jest.fn() };
+    getCustomerUseCase = { execute: jest.fn() };
+
+    const controller = new CustomerController(
+      createCustomerUseCase as never,
+      getCustomerUseCase as never,
+    );
+
+    app.post('/api/customers', controller.create.bind(controller));
+    app.get('/api/customers/:id', controller.getById.bind(controller));
+
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  it('should create customer on POST /api/customers', async () => {
+    createCustomerUseCase.execute.mockResolvedValue({
+      id: 'f23e4567-e89b-12d3-a456-426614174111',
+      name: 'João Silva',
+      email: 'joao@email.com',
+      phone: '11999999999',
+      createdAt: new Date('2026-04-18T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-18T10:00:00.000Z'),
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/customers',
+      payload: {
+        name: 'João Silva',
+        email: 'joao@email.com',
+        phone: '11999999999',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(createCustomerUseCase.execute).toHaveBeenCalledWith({
+      name: 'João Silva',
+      email: 'joao@email.com',
+      phone: '11999999999',
+    });
+    expect(response.json()).toEqual({
+      id: 'f23e4567-e89b-12d3-a456-426614174111',
+      name: 'João Silva',
+      email: 'joao@email.com',
+      phone: '11999999999',
+      createdAt: '2026-04-18T10:00:00.000Z',
+      updatedAt: '2026-04-18T10:00:00.000Z',
+    });
+  });
+
+  it('should return ValidationError for invalid create payload', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/customers',
+      payload: {
+        name: 'A',
+        email: 'not-an-email',
+        phone: '',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual(
+      expect.objectContaining({
+        error: 'ValidationError',
+        message: 'Dados inválidos',
+      }),
+    );
+  });
+
+  it('should return CustomerAlreadyExistsException envelope on duplicate customer', async () => {
+    createCustomerUseCase.execute.mockRejectedValue(new CustomerAlreadyExistsException());
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/customers',
+      payload: {
+        name: 'João Silva',
+        email: 'joao@email.com',
+        phone: '11999999999',
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      error: 'CustomerAlreadyExistsException',
+      message: 'Cliente já cadastrado',
+    });
+  });
+
+  it('should return customer on GET /api/customers/:id', async () => {
+    getCustomerUseCase.execute.mockResolvedValue({
+      id: 'f23e4567-e89b-12d3-a456-426614174111',
+      name: 'João Silva',
+      email: 'joao@email.com',
+      phone: '11999999999',
+      createdAt: new Date('2026-04-18T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-18T10:00:00.000Z'),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/customers/f23e4567-e89b-12d3-a456-426614174111',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(getCustomerUseCase.execute).toHaveBeenCalledWith('f23e4567-e89b-12d3-a456-426614174111');
+    expect(response.json()).toEqual({
+      id: 'f23e4567-e89b-12d3-a456-426614174111',
+      name: 'João Silva',
+      email: 'joao@email.com',
+      phone: '11999999999',
+      createdAt: '2026-04-18T10:00:00.000Z',
+      updatedAt: '2026-04-18T10:00:00.000Z',
+    });
+  });
+
+  it('should return CustomerNotFoundException envelope when customer does not exist', async () => {
+    getCustomerUseCase.execute.mockRejectedValue(new CustomerNotFoundException());
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/customers/f23e4567-e89b-12d3-a456-426614174111',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: 'CustomerNotFoundException',
+      message: 'Cliente não encontrado',
+    });
+  });
+});

--- a/apps/api/src/controllers/customer.controller.spec.ts
+++ b/apps/api/src/controllers/customer.controller.spec.ts
@@ -1,0 +1,87 @@
+import { FastifyReply } from 'fastify';
+
+import { Customer } from '@domain/index';
+
+import { CustomerController } from './customer.controller';
+
+const makeCustomer = (): Customer => {
+  const customer = new Customer();
+  customer.id = 'f23e4567-e89b-12d3-a456-426614174111';
+  customer.name = 'João Silva';
+  customer.email = 'joao@email.com';
+  customer.phone = '11999999999';
+  customer.createdAt = new Date('2026-04-18T10:00:00.000Z');
+  customer.updatedAt = new Date('2026-04-18T10:00:00.000Z');
+  return customer;
+};
+
+describe('CustomerController', () => {
+  let createCustomerUseCase: { execute: jest.Mock };
+  let getCustomerUseCase: { execute: jest.Mock };
+  let controller: CustomerController;
+
+  beforeEach(() => {
+    createCustomerUseCase = { execute: jest.fn() };
+    getCustomerUseCase = { execute: jest.fn() };
+    controller = new CustomerController(
+      createCustomerUseCase as never,
+      getCustomerUseCase as never,
+    );
+  });
+
+  it('should create customer and return 201 response', async () => {
+    const customer = makeCustomer();
+    createCustomerUseCase.execute.mockResolvedValue(customer);
+
+    const request = {
+      body: {
+        name: customer.name,
+        email: customer.email,
+        phone: customer.phone,
+      },
+    } as unknown;
+
+    const send = jest.fn();
+    const status = jest.fn().mockReturnValue({ send });
+    const reply = { status } as unknown as FastifyReply;
+
+    await controller.create(request as never, reply);
+
+    expect(createCustomerUseCase.execute).toHaveBeenCalledWith({
+      name: customer.name,
+      email: customer.email,
+      phone: customer.phone,
+    });
+    expect(status).toHaveBeenCalledWith(201);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: customer.id,
+        email: customer.email,
+      }),
+    );
+  });
+
+  it('should return customer on getById and 200 response', async () => {
+    const customer = makeCustomer();
+    getCustomerUseCase.execute.mockResolvedValue(customer);
+
+    const request = {
+      params: { id: customer.id },
+    } as unknown;
+
+    const send = jest.fn();
+    const status = jest.fn().mockReturnValue({ send });
+    const reply = { status } as unknown as FastifyReply;
+
+    await controller.getById(request as never, reply);
+
+    expect(getCustomerUseCase.execute).toHaveBeenCalledWith(customer.id);
+    expect(status).toHaveBeenCalledWith(200);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: customer.id,
+        email: customer.email,
+      }),
+    );
+  });
+});

--- a/apps/api/src/controllers/customer.controller.ts
+++ b/apps/api/src/controllers/customer.controller.ts
@@ -1,0 +1,58 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { inject, injectable } from 'tsyringe';
+
+import { CreateCustomerUseCase, Customer, GetCustomerUseCase } from '@domain/index';
+
+import {
+  createCustomerBodySchema,
+  CreateCustomerBodySchema,
+  customerParamsSchema,
+  CustomerParamsSchema,
+} from '../http/schemas';
+
+type CustomerResponse = {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * Controller responsible for customer HTTP endpoints.
+ */
+@injectable()
+export class CustomerController {
+  constructor(
+    @inject('CreateCustomerUseCase')
+    private readonly createCustomerUseCase: CreateCustomerUseCase,
+    @inject('GetCustomerUseCase')
+    private readonly getCustomerUseCase: GetCustomerUseCase,
+  ) {}
+
+  async create(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const body = createCustomerBodySchema.parse(request.body) as CreateCustomerBodySchema;
+    const customer = await this.createCustomerUseCase.execute(body);
+
+    reply.status(201).send(this.toResponse(customer));
+  }
+
+  async getById(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const params = customerParamsSchema.parse(request.params) as CustomerParamsSchema;
+    const customer = await this.getCustomerUseCase.execute(params.id);
+
+    reply.status(200).send(this.toResponse(customer));
+  }
+
+  private toResponse(customer: Customer): CustomerResponse {
+    return {
+      id: customer.id,
+      name: customer.name,
+      email: customer.email,
+      phone: customer.phone,
+      createdAt: customer.createdAt.toISOString(),
+      updatedAt: customer.updatedAt.toISOString(),
+    };
+  }
+}

--- a/apps/api/src/http/schemas/__tests__/schemas.spec.ts
+++ b/apps/api/src/http/schemas/__tests__/schemas.spec.ts
@@ -1,7 +1,9 @@
 import Fastify from 'fastify';
 
 import {
+  createCustomerBodySchema,
   createOrderBodySchema,
+  customerParamsSchema,
   idParamSchema,
   listOrdersQuerySchema,
   listProductsQuerySchema,
@@ -70,6 +72,42 @@ describe('http zod schemas', () => {
           items: [{ productId: '323e4567-e89b-12d3-a456-426614174002', quantity: 2 }],
         }),
       ).toThrow();
+    });
+  });
+
+  describe('createCustomerBodySchema', () => {
+    it('parses valid create customer payload', () => {
+      const parsed = createCustomerBodySchema.parse({
+        name: 'João Silva',
+        email: 'joao@email.com',
+        phone: '11999999999',
+      });
+
+      expect(parsed).toEqual({
+        name: 'João Silva',
+        email: 'joao@email.com',
+        phone: '11999999999',
+      });
+    });
+
+    it('rejects invalid create customer payload', () => {
+      expect(() =>
+        createCustomerBodySchema.parse({
+          name: 'A',
+          email: 'invalid-email',
+          phone: '',
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe('customerParamsSchema', () => {
+    it('parses valid customer id param', () => {
+      const parsed = customerParamsSchema.parse({
+        id: 'f23e4567-e89b-12d3-a456-426614174111',
+      });
+
+      expect(parsed.id).toBe('f23e4567-e89b-12d3-a456-426614174111');
     });
   });
 

--- a/apps/api/src/http/schemas/customers.schema.ts
+++ b/apps/api/src/http/schemas/customers.schema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+import {
+  domainErrorResponseSchema,
+  idParamSchema,
+  isoDateTimeSchema,
+  uuidSchema,
+} from './shared/common.schema';
+
+export const createCustomerBodySchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(2, 'name deve ter no mínimo 2 caracteres')
+      .max(100, 'name deve ter no máximo 100 caracteres'),
+    email: z.string().trim().email('email deve ser um email válido').max(255),
+    phone: z
+      .string()
+      .trim()
+      .regex(/^\+?[1-9]\d{7,14}$/, 'phone deve estar no formato E.164'),
+  })
+  .strict();
+
+export type CreateCustomerBodySchema = z.infer<typeof createCustomerBodySchema>;
+
+export const customerParamsSchema = idParamSchema;
+
+export type CustomerParamsSchema = z.infer<typeof customerParamsSchema>;
+
+export const customerResponseSchema = z.object({
+  id: uuidSchema,
+  name: z.string(),
+  email: z.string().email(),
+  phone: z.string(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export type CustomerResponseSchema = z.infer<typeof customerResponseSchema>;
+
+export const customerNotFoundResponseSchema = domainErrorResponseSchema.extend({
+  error: z.literal('CustomerNotFoundException'),
+  message: z.literal('Cliente não encontrado'),
+});
+
+export type CustomerNotFoundResponseSchema = z.infer<typeof customerNotFoundResponseSchema>;
+
+export const customerAlreadyExistsResponseSchema = domainErrorResponseSchema.extend({
+  error: z.literal('CustomerAlreadyExistsException'),
+  message: z.literal('Cliente já cadastrado'),
+});
+
+export type CustomerAlreadyExistsResponseSchema = z.infer<
+  typeof customerAlreadyExistsResponseSchema
+>;

--- a/apps/api/src/http/schemas/index.ts
+++ b/apps/api/src/http/schemas/index.ts
@@ -16,7 +16,21 @@ export type {
 } from './categories.schema';
 
 export {
+  createCustomerBodySchema,
+  customerAlreadyExistsResponseSchema,
   customerNotFoundResponseSchema,
+  customerParamsSchema,
+  customerResponseSchema,
+} from './customers.schema';
+export type {
+  CreateCustomerBodySchema,
+  CustomerAlreadyExistsResponseSchema,
+  CustomerNotFoundResponseSchema,
+  CustomerParamsSchema,
+  CustomerResponseSchema,
+} from './customers.schema';
+
+export {
   createOrderBodySchema,
   createOrderResponseSchema,
   getOrderResponseSchema,
@@ -31,7 +45,6 @@ export {
   updateOrderStatusBodySchema,
 } from './orders.schema';
 export type {
-  CustomerNotFoundResponseSchema,
   CreateOrderBodySchema,
   CreateOrderResponseSchema,
   GetOrderResponseSchema,

--- a/apps/api/src/plugins/http-schemas.plugin.spec.ts
+++ b/apps/api/src/plugins/http-schemas.plugin.spec.ts
@@ -19,6 +19,12 @@ describe('registerHttpSchemas', () => {
     expect(schemas).toHaveProperty('ProductsListResponse');
     expect(schemas).toHaveProperty('ProductResponse');
 
+    expect(schemas).toHaveProperty('CustomersCreateBody');
+    expect(schemas).toHaveProperty('CustomersParams');
+    expect(schemas).toHaveProperty('CustomerResponse');
+    expect(schemas).toHaveProperty('CustomerNotFoundResponse');
+    expect(schemas).toHaveProperty('CustomerAlreadyExistsResponse');
+
     expect(schemas).toHaveProperty('OrdersCreateBody');
     expect(schemas).toHaveProperty('OrdersParams');
     expect(schemas).toHaveProperty('OrdersListQuery');

--- a/apps/api/src/plugins/http-schemas.plugin.ts
+++ b/apps/api/src/plugins/http-schemas.plugin.ts
@@ -3,10 +3,14 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import {
   categoryNotFoundResponseSchema,
-  customerNotFoundResponseSchema,
   categoryParamsSchema,
+  createCustomerBodySchema,
   createOrderBodySchema,
   createOrderResponseSchema,
+  customerAlreadyExistsResponseSchema,
+  customerNotFoundResponseSchema,
+  customerParamsSchema,
+  customerResponseSchema,
   getCategoryResponseSchema,
   getOrderResponseSchema,
   getOrderStatusResponseSchema,
@@ -48,6 +52,12 @@ const SCHEMA_REGISTRY: RegisteredZodSchema[] = [
   { id: 'ProductNotFoundResponse', schema: productNotFoundResponseSchema },
   { id: 'ProductNotFoundByIdResponse', schema: productNotFoundByIdResponseSchema },
 
+  { id: 'CustomersCreateBody', schema: createCustomerBodySchema },
+  { id: 'CustomersParams', schema: customerParamsSchema },
+  { id: 'CustomerResponse', schema: customerResponseSchema },
+  { id: 'CustomerNotFoundResponse', schema: customerNotFoundResponseSchema },
+  { id: 'CustomerAlreadyExistsResponse', schema: customerAlreadyExistsResponseSchema },
+
   { id: 'OrdersCreateBody', schema: createOrderBodySchema },
   { id: 'OrdersParams', schema: orderParamsSchema },
   { id: 'OrdersListQuery', schema: listOrdersQuerySchema },
@@ -57,7 +67,6 @@ const SCHEMA_REGISTRY: RegisteredZodSchema[] = [
   { id: 'OrderStatusResponse', schema: getOrderStatusResponseSchema },
   { id: 'OrdersListResponse', schema: listOrdersResponseSchema },
   { id: 'OrderNotFoundResponse', schema: orderNotFoundResponseSchema },
-  { id: 'CustomerNotFoundResponse', schema: customerNotFoundResponseSchema },
   { id: 'InsufficientStockResponse', schema: insufficientStockResponseSchema },
   { id: 'InsufficientStockDetailedResponse', schema: insufficientStockDetailedResponseSchema },
 

--- a/apps/api/src/routes/customer.routes.spec.ts
+++ b/apps/api/src/routes/customer.routes.spec.ts
@@ -1,0 +1,27 @@
+import 'reflect-metadata';
+
+import Fastify from 'fastify';
+import { container } from 'tsyringe';
+
+import { registerCustomerRoutes } from './customer.routes';
+
+describe('registerCustomerRoutes', () => {
+  afterEach(() => {
+    container.clearInstances();
+    jest.restoreAllMocks();
+  });
+
+  it('should register customer POST and GET endpoints', async () => {
+    const app = Fastify({ logger: false });
+
+    container.registerInstance('CreateCustomerUseCase', { execute: jest.fn() });
+    container.registerInstance('GetCustomerUseCase', { execute: jest.fn() });
+
+    await registerCustomerRoutes(app);
+
+    expect(app.hasRoute({ method: 'POST', url: '/api/customers' })).toBe(true);
+    expect(app.hasRoute({ method: 'GET', url: '/api/customers/:id' })).toBe(true);
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/customer.routes.ts
+++ b/apps/api/src/routes/customer.routes.ts
@@ -1,0 +1,50 @@
+import { FastifyInstance } from 'fastify';
+import { container } from 'tsyringe';
+
+import { CustomerController } from '../controllers/customer.controller';
+import { httpSchemaRef } from '../plugins/http-schemas.plugin';
+
+/**
+ * Registers Customer HTTP routes.
+ */
+export async function registerCustomerRoutes(app: FastifyInstance): Promise<void> {
+  const controller = container.resolve(CustomerController);
+
+  app.post(
+    '/api/customers',
+    {
+      schema: {
+        tags: ['Customers'],
+        summary: 'Cria cliente',
+        operationId: 'createCustomer',
+        body: { $ref: httpSchemaRef('CustomersCreateBody') },
+        response: {
+          201: { $ref: httpSchemaRef('CustomerResponse') },
+          400: { $ref: httpSchemaRef('ValidationErrorResponse') },
+          409: { $ref: httpSchemaRef('CustomerAlreadyExistsResponse') },
+          500: { $ref: httpSchemaRef('InternalServerErrorResponse') },
+        },
+      },
+    },
+    controller.create.bind(controller),
+  );
+
+  app.get(
+    '/api/customers/:id',
+    {
+      schema: {
+        tags: ['Customers'],
+        summary: 'Busca cliente por id',
+        operationId: 'getCustomerById',
+        params: { $ref: httpSchemaRef('CustomersParams') },
+        response: {
+          200: { $ref: httpSchemaRef('CustomerResponse') },
+          400: { $ref: httpSchemaRef('ValidationErrorResponse') },
+          404: { $ref: httpSchemaRef('CustomerNotFoundResponse') },
+          500: { $ref: httpSchemaRef('InternalServerErrorResponse') },
+        },
+      },
+    },
+    controller.getById.bind(controller),
+  );
+}


### PR DESCRIPTION
## Summary
- Adds Customer HTTP layer with  and .
- Introduces Customer Zod schemas, schema registry entries, controller and route wiring in app bootstrap.
- Adds focused unit/integration/route/schema tests for Customer endpoints.

## Validation
- yarn run v1.22.22
$ /home/vwnunes/Projetos/common-cornershop-T8.4/node_modules/.bin/jest --config apps/api/jest.config.ts apps/api/src/controllers/customer.controller.spec.ts apps/api/src/controllers/customer.controller.integration.spec.ts apps/api/src/routes/customer.routes.spec.ts apps/api/src/http/schemas/__tests__/schemas.spec.ts apps/api/src/plugins/http-schemas.plugin.spec.ts --runInBand
Done in 2.20s.
- 

## Roadmap
- Implements T8.4 (Customer controller + routes + Zod schemas).