### PR TITLE
docs(roadmap): sync Fase 7 status with board

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ O documento define as tasks, dependências, paralelismos e critérios de conclus
 | Fase 4 — Quality          | Semana 3–4       | ✅ Concluída |
 | Fase 5 — DevOps Final     | Semana 4         | ⏸️ Em espera |
 | Fase 6 — Pós-MVP Qualidade Técnica | — | ✅ Concluída |
-| Fase 7 — Customer & Stock Side-effects | — | 🔄 Em andamento |
+| Fase 7 — Customer & Stock Side-effects | — | ✅ Concluída |
 
 ---
 
@@ -271,8 +271,8 @@ Nota de status geral:
 - Fase 2 (Core Domain & DB) está agora marcada como CONCLUÍDA — inclui migrations (T3.2) e seeds idempotentes (T3.3).
 - Fase 3 (API Layer) está agora marcada como CONCLUÍDA — T4.1..T4.6 foram entregues (controllers e rotas incluídos). Completamos também a camada de schemas (T4.2) e as implementações de repositório (T4.3).
 - Fase 4 (Quality) está agora marcada como CONCLUÍDA — todos os testes, incluindo E2E (T5.5), foram mergeados (PR #63).
-- Fase 6 (Pós-MVP Qualidade Técnica) iniciada — T7.1 aberta ([#67](https://github.com/Vandrs/common-cornershop/issues/67)): corrigir carregamento de variáveis de ambiente no Jest e eliminar `require()` lazy nos specs de repositório.
- - Fase 7 (Customer & Stock Side-effects) em execução — implementação iniciada. As tasks T8.1 e T8.6 foram mergeadas (PR #78 e PR #79, respectivamente) e as issues correspondentes no board (#69, #70) estão marcadas como Done. As implementações de T8.2, T8.3 e T8.7 foram concluídas em branches e estão atualmente em revisão nas PRs #83 (T8.2), #81 (T8.3) e #82 (T8.7). As issues relacionadas (#71, #72, #73) permanecem abertas e estão em estado "Review" no board. T8.4 permanece bloqueada até que T8.2 e T8.3 sejam mergeadas. T8.5 está pronta para execução.
+ - Fase 6 (Pós-MVP Qualidade Técnica) concluída — T7.1 foi resolvida e a issue [#67](https://github.com/Vandrs/common-cornershop/issues/67) está fechada (Done): correções no carregamento de variáveis de ambiente no Jest e remoção de `require()` lazy nos specs de repositório foram aplicadas. ✅ Concluída.
+ - Fase 7 (Customer & Stock Side-effects) está marcada como CONCLUÍDA — todas as tasks listadas na fase (T8.1..T8.7) foram mergeadas (PRs #78, #79, #83, #81, #82, #87, #88) e as issues correspondentes (#69, #70, #71, #72, #73, #74, #75) foram fechadas e movidas para Done no board. A fase está pronta para validação integrada (testes E2E específicos de customer+stock).
 
 Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (testes unitários com cobertura) são marcos já entregues.
 
@@ -340,15 +340,15 @@ Referências rápidas: T3.3 (seeds), T4.1 (Fastify bootstrap & DI), T5.1/T5.2 (t
 | T8.1 | Domain — Entidade `Customer`: entity, migration, interface de repositório                       | —           |         3h | Alta       | ✅ Concluída |
 | T8.2 | Domain — Use Cases de Customer: `CreateCustomer`, `GetCustomer`                                 | T8.1        |         2h | Alta       | ✅ Concluída |
 | T8.3 | Infra API — `CustomerRepositoryImpl` (TypeORM)                                                  | T8.1        |         2h | Alta       | ✅ Concluída |
-| T8.4 | Infra API — Controller + rotas + Zod schemas de Customer                                        | T8.2, T8.3  |         2h | Média      | ⏳ Pendente  |
-| T8.5 | Domain — Adicionar `customerId` na `Order` + migration                                          | T8.1        |         2h | Alta       | ⏳ Pendente  |
+| T8.4 | Infra API — Controller + rotas + Zod schemas de Customer                                        | T8.2, T8.3  |         2h | Média      | ✅ Concluída |
+| T8.5 | Domain — Adicionar `customerId` na `Order` + migration                                          | T8.1        |         2h | Alta       | ✅ Concluída |
 | T8.6 | Domain — Débito de estoque em `PENDING → PROCESSING` (`UpdateOrderStatusUseCase`)               | —           |         2h | Alta       | ✅ Concluída |
 | T8.7 | Domain — Estorno de estoque em `PROCESSING → CANCELLED` (`CancelOrderUseCase` + `UpdateOrderStatusUseCase`) | T8.6 |    1h | Alta       | ✅ Concluída |
 
 **Paralelismo:**
- - T8.1 (Concluída — PR #78, board issue #69 Done) desbloqueou T8.2, T8.3 e T8.5. As implementações de T8.2, T8.3 e T8.7 foram mergeadas (PRs #83, #81 e #82 respectivamente) e as issues relacionadas (#71, #72, #73) foram fechadas e movidas para Done no board.
- - T8.6 (Concluída — PR #79, board issue #70 Done) desbloqueou T8.7 (mergeada).
- - Observação: T8.6 foi independente e pôde rodar em paralelo com T8.1; como consequência da merge de T8.2 e T8.3, T8.4 foi desbloqueada e pode ser iniciada. T8.5 permanece pronta para execução.
+ - T8.1 (Concluída — PR #78, board issue #69 Done) desbloqueou as tarefas seguintes. As implementações de T8.2 (PR #83), T8.3 (PR #81), T8.7 (PR #82), T8.5 (PR #87) e T8.4 (PR #88) foram mergeadas e as issues relacionadas (#71, #72, #73, #74, #75) foram fechadas e movidas para Done no board.
+ - T8.6 (Concluída — PR #79, board issue #70 Done) também foi mergeada e contribuiu para desbloquear a sequência de alterações necessárias para efeitos de estoque.
+ - Observação: T8.6 foi independente e pôde rodar em paralelo com T8.1; com as merges referidas acima, todas as tasks listadas em Fase 7 estão concluídas e a fase está pronta para validação integrada (testes E2E específicos de customer+stock).
 
 - Critério de conclusão: endpoints `POST /api/customers` e `GET /api/customers/:id` funcionais; `POST /api/orders` exige `customerId` válido; estoque é debitado ao confirmar pedido e devolvido ao cancelar.
 


### PR DESCRIPTION
## Summary
- synchronize `docs/roadmap.md` with the GitHub Project board, which is the canonical source of truth
- mark Fase 7 and tasks T8.4/T8.5 as concluded, and remove stale review/pending notes for T8.2/T8.3/T8.7
- keep T6.2 as on hold and align the high-level project status with the current board state