### PR TITLE
docs(agents): forbid direct commits to main by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,47 @@ When multiple agents run simultaneously and each creates a new git branch, a rac
 3. If branches must be created in parallel, prefer having each agent do `git checkout -b <branch> main` from a clean state, and validate with `git status` before staging files.
 4. Never assume the working branch is correct — always verify programmatically.
 
+### Mandatory branch & commit rule (applies to humans and agents)
+
+- Never commit directly on `main` by default. All work must be done on a feature/fix/docs branch and delivered through a Pull Request.
+- Before every commit (automated or manual), verify the current branch with:
+
+  git branch --show-current
+
+  This check is mandatory for agents and contributors. Automation that performs commits must include an explicit guard that fails the action if the current branch is `main`.
+
+### Exceptions
+
+- An exception to commit on `main` is allowed only when a named stakeholder requests it explicitly and at least one human maintainer approves the request in writing (issue comment, Slack/Email thread, or PR). The approval must be recorded in the related issue or PR.
+- Even with approval, prefer creating a short-lived branch from `main`, applying the change, opening a PR, and merging through the normal flow. Force-pushes to `main` are prohibited unless explicitly authorized by maintainers and accompanied by a rollback plan.
+
+### Recovery procedure (if a commit lands on `main` accidentally)
+
+1. If the commit is local and has NOT been pushed to origin:
+
+   - Create a branch from the current `main` to preserve the work:
+
+     git branch fix/<short-desc>
+
+   - Reset local `main` back to origin/main (safe non-destructive):
+
+     git reset --hard origin/main
+
+   - Checkout the new branch and continue work there:
+
+     git checkout fix/<short-desc>
+
+2. If the commit has been pushed to `origin/main`:
+
+   - Do NOT force-push to rewrite history unless there is explicit, recorded approval from maintainers and the stakeholder. Force-pushing shared history is disruptive.
+   - Immediately notify maintainers (create an issue, tag maintainers, and include the bad commit SHA and a short description).
+   - Create a branch from `origin/main` (which contains the accidental commit), and create a revert PR that either:
+     - Uses `git revert <sha>` to produce a revert commit and PR back into `main`, or
+     - Cherry-picks the intended commits onto a clean branch and open a PR that restores the desired state.
+   - If the accidental commit must be removed urgently and force-push is approved, document the approval in the issue and follow the documented force-push recovery steps (coordinate with CI to avoid automated deployments during the recovery window).
+
+See docs/agent-runbook.md for an operational checklist and step-by-step recovery templates.
+
 
 ## Autonomous Delivery State Machine (Mandatory)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,26 @@
 - If roadmap/board diverge, board wins and roadmap must be synced within SLA.
 
 Execution details: docs/agent-runbook.md
+
+## Branch & Commit Policy (Mandatory)
+
+To keep the repository and board workflow safe and auditable the following rules are mandatory for all contributors and automated agents interacting with this repo:
+
+- Never commit directly on `main` by default. All changes (code, docs, roadmap edits) must be implemented on a branch and submitted through a Pull Request.
+- Before every commit (automated or manual), verify the current branch with:
+
+  git branch --show-current
+
+  This verification is required in local workflows and must be enforced by automation where possible (pre-commit hooks, CI guards). Commits must fail if the active branch is `main`.
+- Branch naming: follow existing conventions (e.g., `feat/`, `fix/`, `docs/`, `chore/`) and include the issue/board ID when applicable.
+- PR-first workflow: open a PR for every change, reference the issue/board card, and move the board state according to the Roadmap ↔ Board Sync Policy.
+
+### Exception process
+
+- An exception to commit on `main` is permitted only when a named stakeholder explicitly requests it and at least one human maintainer approves in writing (issue comment, Slack/Email thread, or PR). Record approval in the related issue or PR.
+- Prefer creating a short-lived branch from `main` and merging via PR even when approval is granted. Force-pushes to `main` are forbidden unless explicitly authorized and accompanied by a documented rollback plan.
+
+### Enforcement & PR checks
+
+- Reviewers must verify in the PR checklist that no commits were made directly to `main` and that the branch verification step was followed when applicable.
+- CI should include a guard that fails merges or automated commits originating from `main` without the documented exception (see docs/agent-runbook.md for checklist templates).

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -15,6 +15,20 @@ Notes:
 - Use worktrees para evitar que múltiplos agentes escrevam na mesma cópia da branch local.
 - Sempre verifique o branch base antes de criar o worktree (evitar drift do main).
 
+## Mandatory branch verification & commit policy
+
+- Never commit directly on `main` by default. Work must be done on a branch and delivered via a Pull Request.
+- Before every commit (automated or manual), verify the current branch with:
+
+  git branch --show-current
+
+  Agents and contributors must include this check in local scripts or pre-commit hooks. Automation that performs commits must assert the active branch is not `main` and fail otherwise.
+
+### Exception and approvals
+
+- Exceptions are only allowed when a named stakeholder explicitly requests the change and at least one human maintainer approves in writing (issue comment, Slack/Email thread, or PR). Approval must be recorded and linked to the work.
+- Prefer creating a short-lived branch from `main` and merging via PR even when exception is granted. Force-pushes to `main` are strongly discouraged and require a documented rollback plan.
+
 ## Status sync sequence (board is canonical)
 
 Follow the official state machine: Backlog -> In Progress -> Review -> Done.
@@ -33,6 +47,30 @@ Rationale: o board é canônico para estado de trabalho; PR/merge é a fonte de 
 - [ ] Evitar duplicação textual: não replicar o mesmo conteúdo no roadmap, notas e PR description — referencie a fonte única quando existir.
 - [ ] Verificar consistência final entre PR, Issue, Board e (quando aplicável) Roadmap; títulos e IDs devem bater.
 - [ ] Evitar mudanças fora do escopo declarado pela issue/task — se necessário, abrir nova issue ou separar em outro PR.
+
+## Pre-commit & PR checklist (operational - add to automation)
+
+- [ ] git branch --show-current != main (mandatory)
+- [ ] Tests and linters pass in the worktree
+- [ ] PR references issue/board card and includes approval evidence if exception applied
+- [ ] Commit messages compact and meaningful; squash when necessary for PR clarity
+
+### Recovery checklist: accidental commit to main
+
+1. Local, NOT pushed to origin:
+
+   - Create a branch to preserve work: `git branch fix/<short-desc>`
+   - Reset local main to remote: `git reset --hard origin/main`
+   - Checkout the new branch and continue work: `git checkout fix/<short-desc>`
+
+2. Pushed to `origin/main`:
+
+   - Do NOT force-push unless explicit recorded approval exists.
+   - Notify maintainers immediately and open an issue with the bad commit SHA and description.
+   - Create a revert PR using `git revert <sha>` or cherry-pick intended commits onto a new branch and open a PR to restore the intended state.
+   - If force-push removal is approved, document approval in the issue and coordinate with CI to avoid automated deployments during remediation.
+
+Add these checklists to local agent scripts, pre-commit hooks, and CI where possible to enforce the rules.
 
 Checklist rápido de qualidade:
 - Compacte mensagens de commit quando fizer sentido para legibilidade do PR.


### PR DESCRIPTION
## Summary
- add an explicit no-direct-commit policy to `main` across `AGENTS.md`, `CONTRIBUTING.md`, and `docs/agent-runbook.md`
- require `git branch --show-current` before every commit and document the exception/approval path
- add recovery steps for accidental commits on local `main` or `origin/main`