### PR TITLE
docs(bot-ia): defer event broker and close pending architecture decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ Decision record: single global `fastify.setErrorHandler` registered at bootstrap
 
 Decision record: soft-delete de uma Order NÃO aplica cascade soft-delete em OrderItems; responsabilidades de filtragem operacional ficam com repositórios/serviços/read-models.
 
+### [`docs/adr/0004-bot-audit-events-append-only.md`](docs/adr/0004-bot-audit-events-append-only.md)
+
+Decision record: `bot_audit_events` (auditoria do Bot de Vendas IA) é uma tabela append-only, sem soft-delete/`deletedAt`, divergindo da convenção padrão de `BaseEntity`. Exclusão física apenas via rotina de retenção (purge), nunca via soft-delete aplicacional.
+
 ## Real Domain Structure (as implemented)
 
 The actual directory layout in `libs/domain/src/` is **flat by type**, not nested by module:

--- a/docs/adr/0004-bot-audit-events-append-only.md
+++ b/docs/adr/0004-bot-audit-events-append-only.md
@@ -1,0 +1,84 @@
+# ADR-0004: 🗒️ `bot_audit_events` como tabela append-only (sem soft-delete)
+
+## Status
+
+Aceito
+
+## Contexto
+
+O documento `docs/bot-ia-architecture.md` define a arquitetura do Bot de Vendas IA (LangChain + LangGraph), incluindo uma tabela de auditoria `bot_audit_events` no PostgreSQL para registrar eventos críticos do bot (ex.: `order_creation_attempted`, `order_created`, `intent_detected`), usada tanto para auditoria/compliance quanto como fonte de dados para observability e pipelines de ML feedback.
+
+Todas as entidades do domínio hoje seguem a convenção padrão de `BaseEntity` (`id`, `createdAt`, `updatedAt`, `deletedAt`), com soft-delete conforme `docs/database.md` e `docs/domain-model.md`.
+
+Ao desenhar `bot_audit_events`, identificamos um conflito com essa convenção:
+
+- Uma trilha de auditoria precisa ser imutável — permitir soft-delete (ou qualquer forma de exclusão/edição) em registros de auditoria contradiz o próprio propósito de auditoria e explicabilidade descrito nos guardrails de `create_order` (item 4 — "Audit e explicabilidade").
+- Não há caso de uso legítimo para "restaurar" um evento de auditoria soft-deletado — diferente de entidades transacionais como `Order`, cujo histórico pode precisar de correção/estorno.
+- Aplicar `BaseEntity` traria uma coluna `deletedAt` sem significado operacional, criando ambiguidade sobre se registros de auditoria podem ou não ser removidos logicamente.
+
+## Decisão
+
+`bot_audit_events` será uma tabela **append-only**, ou seja:
+
+- Não estende `BaseEntity`. Não possui coluna `deletedAt` nem `updatedAt` — registros são escritos uma única vez e nunca atualizados.
+- Campos mínimos: `id` (uuid), `occurred_at` (timestamptz, default `now()`), `event_type` (text), `client_id`, `session_id`, `idempotency_token`, `payload` (jsonb), `processed` (boolean, default `false`) — usado apenas para marcar consumo por pipelines downstream (ex.: ML feedback), nunca para ocultar/expirar o registro em si.
+- Exclusão física só ocorre via rotina de retenção (purge), nunca via soft-delete aplicacional. A rotina de retenção respeita a política definida em `docs/bot-ia-architecture.md`: 7 dias em desenvolvimento/local (uso de estudos) e 30 dias em staging/produção, configurável via variável de ambiente (ex.: `AUDIT_RETENTION_DAYS`).
+- Nenhum endpoint da API deve expor operação de update/delete lógico sobre `bot_audit_events`; leitura é sempre read-only para consumidores externos (observability, ML feedback).
+
+## Consequências
+
+Positivas
+
+- Garantia de imutabilidade da trilha de auditoria — alinhado ao guardrail de "Audit e explicabilidade" do bot.
+- Simplifica o modelo: sem necessidade de filtros `deletedAt IS NULL` em nenhuma query de leitura desta tabela.
+- Reduz risco de um bug de aplicação apagar/ocultar evidências de auditoria acidentalmente.
+
+Negativas / Trade-offs
+
+- Diverge da convenção padrão do domínio (`BaseEntity`), exigindo atenção extra de quem for revisar código/migrations dessa entidade — deve ficar claro (via comentário no código e nesta ADR) que essa é uma exceção intencional.
+- Crescimento de volume ao longo do tempo, mitigado pela rotina de retenção (purge por idade), que precisa ser implementada como job/scheduled task e testada.
+- Sem `deletedAt`, qualquer necessidade futura de "anonimizar" PII em eventos antigos (por exemplo, por solicitação de titular de dados) exigirá um mecanismo específico de redação de payload em vez de soft-delete — deve ser tratado à parte se/quando necessário.
+
+## Alternativas consideradas
+
+| Alternativa | Descrição | Por que foi descartada / observações |
+| --- | --- | --- |
+| Estender `BaseEntity` (com soft-delete) | Usar o padrão default do domínio, incluindo `deletedAt` | Contradiz o propósito de imutabilidade da auditoria; nenhum fluxo de negócio precisa "restaurar" um evento de auditoria. Descartada. |
+| Tabela mutável com campo `isArchived` | Registro pode ser marcado como arquivado em vez de deletado | Não resolve o problema real (imutabilidade); adiciona complexidade sem benefício claro sobre apenas usar `processed` para consumo. Não escolhida. |
+| Streaming direto para um Event Broker (sem tabela local) | Substituir a tabela por publish direto em Kafka/RabbitMQ | Já descartado por decisão anterior — Event Broker adiado até existir consumidor real definido (ver `docs/bot-ia-architecture.md`, seção "Decisões registradas"). |
+
+## Compatibilidade com o roadmap / arquitetura do bot
+
+- Esta ADR é específica da fase "Bot de Vendas IA" (`docs/bot-ia-architecture.md`), ainda não incluída como fase formal em `docs/roadmap.md`.
+- Ao criar a migration `{timestamp}-CreateBotAuditEventsTable.ts`, seguir a convenção de nomenclatura de `docs/database.md`, mas sem incluir a coluna `deletedAt` e sem registrar a entidade com o comportamento padrão de soft-delete do TypeORM.
+- Ao registrar a entidade em `data-source.ts`, documentar no próprio arquivo de entidade (comentário JSDoc) que ela não estende `BaseEntity` por decisão desta ADR.
+
+## Plano de revisão futura
+
+Revisar esta decisão nas seguintes circunstâncias:
+
+1. Se surgir um requisito legal/negócio de anonimização ou remoção de dados de auditoria (ex.: solicitação de exclusão de dados pessoais) — reavaliar se é necessário um mecanismo de redação de payload em vez de soft-delete.
+2. Quando a fase Bot IA for formalizada em `docs/roadmap.md`, revisar se o volume real observado ainda é compatível com a política de retenção definida (7/30 dias) ou se precisa ser recalibrada.
+3. Ao introduzir o Event Broker (quando houver consumidor real definido), reavaliar se `bot_audit_events` permanece como fonte primária ou passa a ser um buffer/staging antes da publicação de eventos.
+
+## Referências
+
+- `docs/bot-ia-architecture.md` — arquitetura do Bot de Vendas IA, seção "Auditoria & Observability" e "Decisões registradas".
+- `docs/database.md` — convenções de migrations e soft-delete.
+- `docs/domain-model.md` — `BaseEntity` e entidades padrão do domínio.
+- ADR-0003 (`docs/adr/0003-soft-delete-order-orderitems.md`) — outra decisão que trata de exceções à convenção padrão de soft-delete.
+
+## Checklist de verificação
+
+1. Terminologia consistente: `bot_audit_events`, append-only, `BaseEntity` — verificado.
+2. Diagrama-texto parity: não aplicável (sem diagrama próprio; referencia o diagrama de componentes do doc de arquitetura do bot).
+3. Exemplos de schema: incluídos em `docs/bot-ia-architecture.md` (seção "Auditoria & Observability").
+4. Plano de migração/rollback: exclusão apenas via rotina de purge por retenção; sem rollback de soft-delete aplicável (tabela não suporta soft-delete).
+5. Segurança & Compliance: retenção definida por ambiente (7 dias dev/local, 30 dias staging/produção); redação de PII no payload deve seguir a mesma política de logs estruturados do doc de arquitetura do bot.
+6. Performance targets: overhead mínimo esperado (baixo volume — uso de estudos); índice recomendado em `event_type` e `occurred_at` caso o volume cresça.
+
+Se algum item não estiver cumprido, abrir issue `maintainer-review` referenciando este ADR.
+
+## Changelog
+
+- 2026-07-12: Criação do ADR-0004 — decisão de que `bot_audit_events` é uma tabela append-only, sem soft-delete, divergindo da convenção padrão de `BaseEntity`. (autor: arquitetura)

--- a/docs/bot-ia-architecture.md
+++ b/docs/bot-ia-architecture.md
@@ -118,6 +118,8 @@ Exemplo de registro (payload json armazenado em payload):
 ```
 
    - Observability e pipelines de ML feedback devem consumir dados a partir dos logs estruturados e da tabela de auditoria. O uso de um Event Broker (Kafka/RabbitMQ/cloud pubsub) fica adiado — será reavaliado quando existir um consumidor real definido (ex.: analytics, integração com canal WhatsApp). Quando o broker for necessário, sugerimos uma migração com dual-write/bridging e esquema de eventos versionado.
+   - Retenção (decisão registrada): configurável por ambiente via variável de ambiente (ex.: `LOG_RETENTION_DAYS` / `AUDIT_RETENTION_DAYS`) — 7 dias em desenvolvimento/local (uso de estudos) e 30 dias em staging/produção.
+   - `bot_audit_events` é uma tabela append-only (sem soft-delete/`deletedAt`), divergindo da convenção padrão de `BaseEntity`. Decisão formalizada em [ADR-0004](adr/0004-bot-audit-events-append-only.md).
 
 ## Data, eventos e contratos
 
@@ -170,7 +172,7 @@ Versionamento de eventos
 Idempotência e garantias
 
 - Todos comandos de escrita (ex.: createOrder) obrigatoriamente carregam idempotency_token.
-- Server-side: Order UseCase deve atender idempotency_token e retornar o mesmo order_id se token já usado no prazo configurado (ex.: 24h).
+- Server-side: Order UseCase deve atender idempotency_token e retornar o mesmo order_id se token já usado no prazo configurado. TTL decidido: 24 horas.
 
 ## API / Contratos de mensagem (exemplos)
 
@@ -293,7 +295,8 @@ Métrica mínima necessária (Go)
 - Latência: tempo p/ resposta crítica (confirm prompt + create_order end-to-end) < 2s para 95 percentil em staging.
 - Idempotência: 100% de determinismo para requests com mesmo idempotency_token em testes automatizados.
 - Observability: logs estruturados, métricas (intent_accuracy, order_creation_rate, order_creation_failures), traces e alertas configurados.
-- Segurança & Compliance: secrets manager integrado, access controls, PII handling definido (client_id é permitido; dados sensíveis não devem vazar para LLM context).
+- Segurança & Compliance: secrets via variável de ambiente (.env) validada com Zod (mesmo padrão de `apps/api/src/config/database.config.ts`), access controls, PII handling definido (client_id é permitido; dados sensíveis não devem vazar para LLM context).
+- Capacidade/volume: baixo volume (uso pessoal/demonstração de estudos) — não há requisito de otimização para escala nesta fase; a meta de latência (p95 < 2s) é calibrada para esse cenário.
 
 No-Go (exemplos)
 
@@ -310,7 +313,7 @@ Nota: sem uma fase de prototipagem separada com ferramentas low-code, a validaç
    - Mensagem de confirmação deve incluir resumo do pedido (itens, quantidades, total estimado) em pt-BR informal.
 
 2. Idempotência
-   - Exigir idempotency_token gerado pelo cliente (Webchat Adapter). Token TTL configurável (ex.: 24h).
+   - Exigir idempotency_token gerado pelo cliente (Webchat Adapter). Token TTL: 24 horas (decisão registrada).
    - Server-side: reuso do mesmo order_id ao receber token previamente processado; retorno de 200/201 consistente.
 
 3. Verificações de negócio
@@ -350,10 +353,15 @@ Decisões registradas
 - Canal inicial Webchat; WhatsApp planejado sem prioridade agora.
 - Identificação por client_id; sem pagamento nesta fase.
  - Event Broker removido do escopo atual. Auditoria será feita via logs estruturados + tabela de auditoria no PostgreSQL. O uso de um broker será reavaliado somente quando houver consumidores reais definidos (ex.: analytics, integração com WhatsApp).
+ - TTL do idempotency_token: 24 horas.
+ - Retenção de logs estruturados e prompt history: configurável por ambiente — 7 dias em desenvolvimento/local (uso de estudos) e 30 dias em staging/produção.
+ - Secrets hosting: variável de ambiente (.env) validada via Zod, seguindo o mesmo padrão de `apps/api/src/config/database.config.ts` — sem secrets manager dedicado nesta fase.
+ - Volume/capacidade esperado: baixo volume (uso pessoal/demonstração de estudos); metas de latência e rate limit calibradas para esse cenário.
+ - `bot_audit_events` é uma tabela append-only (sem soft-delete/`deletedAt`), divergindo da convenção padrão de `BaseEntity` — decisão formalizada em [ADR-0004](adr/0004-bot-audit-events-append-only.md).
 
 Decisões pendentes (a serem tomadas antes do Go)
 
-- Políticas exatas de TTL do idempotency_token e retenção de logs/prompt history (retention days).
+- Nenhuma pendência bloqueante identificada no momento — todas as decisões previamente listadas nesta seção foram resolvidas (ver Changelog, 2026-07-12).
 
 ## Migração e rollout plan
 
@@ -394,8 +402,8 @@ Rollout/rollback mechanics
 2. Diagrama-texto parity: check — todos os componentes no diagrama estão descritos.
 3. Exemplos de payloads validos: check — JSONs seguem os campos documentados (incluem version e idempotency_token).
 4. Migração plan completeness: check — fases, canary, rollback, dual-run e feature flags descritos.
-5. Segurança & compliance: partial — recomendações listadas; necessidade de decisão pendente sobre retention e secrets hosting.
-6. Performance targets: partial — latência alvo definido (p95 < 2s) mas capacidade estimada depende do volume (requer input do negócio).
+5. Segurança & compliance: check — retenção definida por ambiente (7 dias dev/local, 30 dias staging/produção) e secrets hosting definido (.env validado com Zod).
+6. Performance targets: check — latência alvo (p95 < 2s) e volume esperado (baixo volume / uso de estudos) definidos.
 
 Se qualquer item parcial/pendente bloquear o Go, listar como impedimento no comitê de revisão.
 
@@ -404,6 +412,7 @@ Se qualquer item parcial/pendente bloquear o Go, listar como impedimento no comi
 - 2026-04-17: Documento inicial criado. Autor: arquitetura.
  - 2026-05-09: Decisão revisada — fase de prototipagem low-code removida; implementação inicia diretamente com LangChain + LangGraph. Provedor LLM definido: OpenRouter + GPT. Hosting: self-hosted no monorepo NX.
  - 2026-05-14: Event Broker removido do escopo atual. Auditoria adotada via logs estruturados + tabela PostgreSQL. Broker será reavaliado se/quando houver consumidor real definido.
+ - 2026-07-12: Decisões pendentes fechadas — TTL do idempotency_token (24h), retenção de logs por ambiente (7 dias dev/local, 30 dias staging/produção), secrets hosting via .env (padrão Zod) e volume esperado (baixo volume / uso de estudos). ADR-0004 criado formalizando `bot_audit_events` como tabela append-only.
 
 ## TODO / Action items (com prioridade e owner sugerido)
 

--- a/docs/bot-ia-architecture.md
+++ b/docs/bot-ia-architecture.md
@@ -62,8 +62,7 @@ flowchart LR
   LangChain -->|graph| LangGraph["LangGraph (Decision Graph)"]
   Orchestrator -->|Query/Command| Domain["Domain Services (UseCases)"]
   Domain -->|SQL| Postgres["(PostgreSQL via TypeORM)"]
-  Orchestrator -->|Audit/Events| Broker["Event Broker (Kafka/Rabbit/Cloud)"]
-  Broker -->|consume| Analytics["Analytics / Observability"]
+  %% Broker and Analytics removed from current scope — auditing handled via logs and DB
 ```
 
 Componentes e responsabilidades
@@ -89,9 +88,36 @@ Componentes e responsabilidades
   - Responsável pela lógica de negócio: validação de pedidos, cálculos, regras de estoque.
   - Expõe comandos idempotentes e eventos de domínio.
 
-- Event Broker & Observability
-  - Captura eventos de audit (order_created_attempt, order_created, order_rejected, intent_detected).
-  - Métricas e logs para auditoria e ML feedback loop.
+ - Auditoria & Observability
+   - Logs estruturados via Fastify (JSON) usando o formato de logging já disponível na infraestrutura. Esses logs devem conter campos padronizados: timestamp, level, service, client_id, session_id, request_id, event_type, payload (hash/redacted quando houver PII), idempotency_token.
+   - Tabela de auditoria no PostgreSQL para eventos críticos do bot (ex.: order_creation_attempted, order_created, intent_detected). Exemplo simplificado de esquema:
+
+```sql
+CREATE TABLE bot_audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  event_type text NOT NULL,
+  client_id text,
+  session_id text,
+  idempotency_token text,
+  payload jsonb,
+  processed boolean DEFAULT false
+);
+```
+
+Exemplo de registro (payload json armazenado em payload):
+
+```json
+{
+  "event_type": "order_creation_attempted",
+  "client_id": "client_123",
+  "session_id": "sess_456",
+  "idempotency_token": "uuid-v4-token",
+  "payload": { "items": [{ "product_id": "prod_1", "qty": 2 }] }
+}
+```
+
+   - Observability e pipelines de ML feedback devem consumir dados a partir dos logs estruturados e da tabela de auditoria. O uso de um Event Broker (Kafka/RabbitMQ/cloud pubsub) fica adiado — será reavaliado quando existir um consumidor real definido (ex.: analytics, integração com canal WhatsApp). Quando o broker for necessário, sugerimos uma migração com dual-write/bridging e esquema de eventos versionado.
 
 ## Data, eventos e contratos
 
@@ -323,11 +349,11 @@ Decisões registradas
 - Hosting do LangChain runtime: self-hosted dentro do monorepo NX (ex.: apps/bot ou libs/orchestration) (decisão tomada).
 - Canal inicial Webchat; WhatsApp planejado sem prioridade agora.
 - Identificação por client_id; sem pagamento nesta fase.
+ - Event Broker removido do escopo atual. Auditoria será feita via logs estruturados + tabela de auditoria no PostgreSQL. O uso de um broker será reavaliado somente quando houver consumidores reais definidos (ex.: analytics, integração com WhatsApp).
 
 Decisões pendentes (a serem tomadas antes do Go)
 
 - Políticas exatas de TTL do idempotency_token e retenção de logs/prompt history (retention days).
-- Mecanismo de event broker recomendado (Kafka vs cloud pubsub vs RabbitMQ).
 
 ## Migração e rollout plan
 
@@ -377,12 +403,13 @@ Se qualquer item parcial/pendente bloquear o Go, listar como impedimento no comi
 
 - 2026-04-17: Documento inicial criado. Autor: arquitetura.
  - 2026-05-09: Decisão revisada — fase de prototipagem low-code removida; implementação inicia diretamente com LangChain + LangGraph. Provedor LLM definido: OpenRouter + GPT. Hosting: self-hosted no monorepo NX.
+ - 2026-05-14: Event Broker removido do escopo atual. Auditoria adotada via logs estruturados + tabela PostgreSQL. Broker será reavaliado se/quando houver consumidor real definido.
 
 ## TODO / Action items (com prioridade e owner sugerido)
 
 - [P1] Implementar idempotency_token pattern no Webchat Adapter e Order UseCase — Owner: Backend — Prioridade: alta
 - [P1] Criar testes de contrato Orchestrator ↔ Domain — Owner: Eng QA — Prioridade: medium
-- [P2] Escolher Event Broker e provisionar staging — Owner: Infra — Prioridade: medium
+<!-- P2 removed: Event Broker deferred until consumer exists -->
 
 ## Anexos (links sugeridos e referências)
 


### PR DESCRIPTION
## Summary

Updates `docs/bot-ia-architecture.md` (Bot de Vendas IA — LangChain + LangGraph architecture doc) and adds a new ADR closing all previously pending decisions before Go/No-Go.

### Commit 1 — Defer Event Broker
- Removes Event Broker/Analytics from the component diagram.
- Renames "Event Broker & Observability" to "Auditoria & Observability".
- Adds `bot_audit_events` PostgreSQL table schema + example payload for bot audit trail.
- Event broker (Kafka/RabbitMQ/cloud pub-sub) deferred until a real consumer is defined (e.g. analytics, WhatsApp integration).

### Commit 2 — Close pending decisions + ADR-0004
- **idempotency_token TTL:** 24 hours.
- **Log/prompt history retention:** configurable per environment — 7 days (dev/local, study use case) / 30 days (staging/prod).
- **Secrets hosting:** environment variables (`.env`) validated with Zod, following the existing `database.config.ts` pattern — no dedicated secrets manager for this phase.
- **Expected volume:** low (personal/demo/study use case) — latency (p95 < 2s) and rate-limit targets calibrated accordingly.
- **New ADR-0004** (`docs/adr/0004-bot-audit-events-append-only.md`): formalizes `bot_audit_events` as an append-only table (no soft-delete/`deletedAt`), diverging from the standard `BaseEntity` convention. Physical deletion only via a retention/purge routine, never application-level soft-delete.
- Updates the Go/No-Go verification checklist (items 5 and 6 now `check` instead of `partial`).
- References ADR-0004 in `AGENTS.md`'s documentation index.

## Why
These were the last open items blocking the Go/No-Go checklist in the bot architecture doc. No code changes — documentation only.

## Test plan
- [x] N/A — documentation-only change, no code/tests affected.
- [x] Verified active branch was not `main` before every commit (`git branch --show-current`).